### PR TITLE
Add jfr and jcmd to jre image

### DIFF
--- a/11/jre/alpine/Dockerfile
+++ b/11/jre/alpine/Dockerfile
@@ -12,7 +12,7 @@ java.rmi,java.security.sasl,java.xml,jdk.internal.vm.ci,jdk.jfr,jdk.management,j
 jdk.naming.rmi,java.compiler,jdk.aot,jdk.internal.vm.compiler,jdk.internal.vm.compiler.management,java.se,java.net.http,java.scripting,java.security.jgss,\
 java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,\
 jdk.dynalink,jdk.httpserver,jdk.jsobject,jdk.localedata,jdk.naming.dns,jdk.scripting.nashorn,jdk.security.auth,jdk.security.jgss,jdk.xml.dom,jdk.zipfs,\
-jdk.jdwp.agent,jdk.pack,jdk.scripting.nashorn.shell" \
+jdk.jdwp.agent,jdk.pack,jdk.scripting.nashorn.shell,jdk.jcmd,jdk.jfr" \
         --no-man-pages --no-header-files --strip-debug --output /temp/java-11-amazon-corretto
 
 


### PR DESCRIPTION
*Description of changes:*
Adds jfr and jcmd to Corretto11 JRE image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
