### PR TITLE
Update Dockerfiles for all Alpine builds to fix permissions.

### DIFF
--- a/11/jdk/alpine/Dockerfile
+++ b/11/jdk/alpine/Dockerfile
@@ -6,7 +6,7 @@ ARG version=11.0.8.10.1
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
-    tar xvzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \

--- a/11/jre/alpine/Dockerfile
+++ b/11/jre/alpine/Dockerfile
@@ -6,7 +6,7 @@ ARG version=11.0.8.10.1
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
-    tar xvzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
@@ -27,6 +27,7 @@ jdk.jdwp.agent,jdk.pack,jdk.scripting.nashorn.shell,jdk.jcmd,jdk.jfr" \
 
 FROM alpine:3.12
 COPY --from=0 /temp/java-11-amazon-corretto /usr/lib/jvm/java-11-amazon-corretto
+COPY --from=0 /licenses /licenses
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
 ENV PATH=$PATH:/usr/lib/jvm/java-11-amazon-corretto/bin

--- a/15/jdk/alpine/Dockerfile
+++ b/15/jdk/alpine/Dockerfile
@@ -6,7 +6,7 @@ ARG version=15.0.0.36.1
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
-    tar xvzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \

--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -6,7 +6,7 @@ ARG version=8.265.01.2
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
-    tar xvzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \

--- a/8/jre/alpine/Dockerfile
+++ b/8/jre/alpine/Dockerfile
@@ -6,7 +6,7 @@ ARG version=8.265.01.2
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
-    tar xvzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
     wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \


### PR DESCRIPTION
The tar extract command was maintaining owner and group on /licenses.
This was causing an issue with Bitbucket image building.

Changing the tar command to use the current user, which is root.
See: https://github.com/corretto/corretto-docker/issues/32
