### PR TITLE
Update docker images to use 15.0.1 and 8.272.10

### DIFF
--- a/.tags
+++ b/.tags
@@ -1,4 +1,4 @@
-Tags: 8, 8u265, 8u265-al2, 8-al2-full,8-al2-jdk, latest
+Tags: 8, 8u272, 8u272-al2, 8-al2-full,8-al2-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
@@ -6,11 +6,11 @@ Tags: 11, 11.0.9, 11.0.9-al2, 11-al2-jdk, 11-al2-full
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 8-alpine, 8u265-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine, 8u272-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64
 Directory: 8/jdk/alpine
 
-Tags: 8-alpine-jre, 8u265-alpine-jre
+Tags: 8-alpine-jre, 8u272-alpine-jre
 Architectures: amd64
 Directory: 8/jre/alpine
 

--- a/15/jdk/al2/Dockerfile
+++ b/15/jdk/al2/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ARG version=15.0.0.36-1
+ARG version=15.0.1.9-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/15/jdk/alpine/Dockerfile
+++ b/15/jdk/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG version=15.0.0.36.1
+ARG version=15.0.1.9.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.

--- a/15/jdk/debian/Dockerfile
+++ b/15/jdk/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ARG version=15.0.0.36-1
+ARG version=15.0.1.9-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/8/jdk/al2/Dockerfile
+++ b/8/jdk/al2/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ARG version=1.8.0_265.b01-1
+ARG version=1.8.0_272.b10-3
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG version=8.265.01.2
+ARG version=8.272.10.4
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.

--- a/8/jdk/debian/Dockerfile
+++ b/8/jdk/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ARG version=8.265.01-1
+ARG version=8.272.10-3
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/8/jre/alpine/Dockerfile
+++ b/8/jre/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG version=8.265.01.2
+ARG version=8.272.10.4
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ aws ecr list-images --region us-west-2 --registry-id 489478819445 --repository-n
 
 
 # Supported Tags
-* [8, 8u265, 8u265-al2, 8-al2-full,8-al2-jdk, latest](https://hub.docker.com/_/amazoncorretto)
+* [8, 8u272, 8u272-al2, 8-al2-full,8-al2-jdk, latest](https://hub.docker.com/_/amazoncorretto)
 * [11, 11.0.9, 11.0.9-al2, 11-al2-jdk, 11-al2-full](https://hub.docker.com/_/amazoncorretto)
-* [8-alpine, 8u265-alpine, 8-alpine-full, 8-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
-* [8-alpine-jre, 8u265-alpine-jre](https://hub.docker.com/_/amazoncorretto)
+* [8-alpine, 8u272-alpine, 8-alpine-full, 8-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
+* [8-alpine-jre, 8u272-alpine-jre](https://hub.docker.com/_/amazoncorretto)
 * [11-alpine, 11.0.9-alpine, 11-alpine-full, 11-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
 * [15, 15-al2-jdk, 15-al2-full](https://hub.docker.com/r/amazoncorretto/amazoncorretto)
 * [15-alpine, 15-alpine-full, 15-alpine-jdk](https://hub.docker.com/r/amazoncorretto/amazoncorretto)

--- a/bin/update-dockerfiles.sh
+++ b/bin/update-dockerfiles.sh
@@ -12,7 +12,9 @@ update_musl_linux() {
     MAJOR_RELEASE=$2
 
     sed -i "" "s/ARG version=.*/ARG version=${CORRETTO_VERSION}/g" ./${MAJOR_RELEASE}/jdk/alpine/Dockerfile
-    sed -i "" "s/ARG version=.*/ARG version=${CORRETTO_VERSION}/g" ./${MAJOR_RELEASE}/jre/alpine/Dockerfile
+    if [ -f ./${MAJOR_RELEASE}/jre/alpine/Dockerfile ]; then
+        sed -i "" "s/ARG version=.*/ARG version=${CORRETTO_VERSION}/g" ./${MAJOR_RELEASE}/jre/alpine/Dockerfile
+    fi
     jdk_version=$(echo ${CORRETTO_VERSION} | cut -d'.' -f1-3)
     sed -i "" "s/${MAJOR_RELEASE}\.0\.[0-9]*-alpine/${jdk_version}-alpine/g" .tags
 


### PR DESCRIPTION
Update docker images to use 15.0.1 and 8.272.10

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
