### PR TITLE
Add Corretto 16.0.0 Docker images and tags

### DIFF
--- a/.github/workflows/verify-images.yml
+++ b/.github/workflows/verify-images.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 8, 11, 15 ]
+        version: [ 8, 11, 15, 16 ]
         package: [ jdk, slim ]
         platform: [ alpine, al2, debian ]
         include:

--- a/.tags
+++ b/.tags
@@ -30,3 +30,18 @@ Tags: 15-alpine, 15.0.2-alpine, 15-alpine-full, 15-alpine-jdk
 Architectures: amd64
 Directory: 15/jdk/alpine
 
+Tags: 16, 16.0.0, 16.0.0-al2, 16-al2-jdk, 16-al2-full
+Architectures: amd64, arm64v8
+Directory: 16/jdk/al2
+
+Tags: 16-slim, 16.0.0-slim, 16.0.0-al2-slim
+Architectures: amd64, arm64v8
+Directory: 16/slim/al2
+
+Tags: 16-alpine, 16.0.0-alpine, 16-alpine-full, 16-alpine-jdk
+Architectures: amd64
+Directory: 16/jdk/alpine
+
+Tags: 16-alpine-slim, 16.0.0-alpine-slim
+Architectures: amd64
+Directory: 16/slim/alpine

--- a/16/jdk/al2/Dockerfile
+++ b/16/jdk/al2/Dockerfile
@@ -1,0 +1,31 @@
+FROM amazonlinux:2
+
+ARG version=16.0.0.36-1
+# In addition to installing the Amazon corretto, we also install
+# fontconfig. The folks who manage the docker hub's
+# official image library have found that font management
+# is a common usecase, and painpoint, and have
+# recommended that Java images include font support.
+#
+# See:
+#  https://github.com/docker-library/official-images/blob/master/test/tests/java-uimanager-font/container.java
+
+# The logic and code related to Fingerprint is contributed by @tianon in a Github PR's Conversation
+# Comment = https://github.com/docker-library/official-images/pull/7459#issuecomment-592242757
+# PR = https://github.com/docker-library/official-images/pull/7459
+RUN set -eux \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fL -o corretto.key https://yum.corretto.aws/corretto.key \
+    && gpg --batch --import corretto.key \
+    && gpg --batch --export --armor '6DC3636DAE534049C8B94623A122542AB04F24E3' > corretto.key \
+    && rpm --import corretto.key \
+    && rm -r "$GNUPGHOME" corretto.key \
+    && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
+    && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
+    && yum install -y java-16-amazon-corretto-devel-$version \
+    && (find /usr/lib/jvm/java-16-amazon-corretto -name src.zip -delete || true) \
+    && yum install -y fontconfig \
+    && yum clean all
+
+ENV LANG C.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/java-16-amazon-corretto

--- a/16/jdk/alpine/Dockerfile
+++ b/16/jdk/alpine/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.12
+
+ARG version=16.0.0.36.1
+
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# The Corretto team will update this file but you may see a few days' delay.
+RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
+    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
+    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
+    apk add --no-cache amazon-corretto-16=$version-r0
+
+ENV LANG C.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/16/jdk/debian/Dockerfile
+++ b/16/jdk/debian/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:buster-slim
+
+ARG version=16.0.0.36-1
+# In addition to installing the Amazon corretto, we also install
+# fontconfig. The folks who manage the docker hub's
+# official image library have found that font management
+# is a common usecase, and painpoint, and have
+# recommended that Java images include font support.
+#
+# See:
+#  https://github.com/docker-library/official-images/blob/master/test/tests/java-uimanager-font/container.java
+
+RUN set -eux \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl ca-certificates gnupg software-properties-common fontconfig java-common \
+    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
+    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
+    && mkdir -p /usr/share/man/man1 || true \
+    && apt-get update \
+    && apt-get install -y java-16-amazon-corretto-jdk=1:$version \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+        curl gnupg software-properties-common
+
+ENV LANG C.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/java-16-amazon-corretto

--- a/16/slim/al2/Dockerfile
+++ b/16/slim/al2/Dockerfile
@@ -1,0 +1,66 @@
+FROM amazonlinux:2
+
+ARG version=16.0.0.36-1
+# In addition to installing the Amazon corretto, we also install
+# fontconfig. The folks who manage the docker hub's
+# official image library have found that font management
+# is a common usecase, and painpoint, and have
+# recommended that Java images include font support.
+#
+# See:
+#  https://github.com/docker-library/official-images/blob/master/test/tests/java-uimanager-font/container.java
+
+# The logic and code related to Fingerprint is contributed by @tianon in a Github PR's Conversation
+# Comment = https://github.com/docker-library/official-images/pull/7459#issuecomment-592242757
+# PR = https://github.com/docker-library/official-images/pull/7459
+#
+# Slim:
+#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
+RUN set -eux \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fL -o corretto.key https://yum.corretto.aws/corretto.key \
+    && gpg --batch --import corretto.key \
+    && gpg --batch --export --armor '6DC3636DAE534049C8B94623A122542AB04F24E3' > corretto.key \
+    && rpm --import corretto.key \
+    && rm -r "$GNUPGHOME" corretto.key \
+    && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
+    && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
+    && yum install -y java-16-amazon-corretto-devel-$version \
+    && (find /usr/lib/jvm/java-16-amazon-corretto -name src.zip -delete || true) \
+    && yum install -y fontconfig \
+    && yum install -y binutils \
+    && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
+    && yum remove -y binutils java-16-amazon-corretto-devel-$version \
+    && mkdir -p /usr/lib/jvm/ \
+    && mv /opt/corretto-slim /usr/lib/jvm/java-16-amazon-corretto \
+    && alternatives --install /usr/bin/java java /usr/lib/jvm/java-16-amazon-corretto/bin/java $(echo "1${version}" | sed "s/\(\.\|-\)//g") \
+                  --slave /usr/bin/keytool keytool /usr/lib/jvm/java-16-amazon-corretto/bin/keytool \
+                  --slave /usr/bin/rmid rmid /usr/lib/jvm/java-16-amazon-corretto/bin/rmid \
+                  --slave /usr/bin/rmiregistry rmiregistry /usr/lib/jvm/java-16-amazon-corretto/bin/rmiregistry \
+    && alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-16-amazon-corretto/bin/javac $(echo "1${version}" | sed "s/\(\.\|-\)//g") \
+                 --slave /usr/bin/jaotc jaotc /usr/lib/jvm/java-16-amazon-corretto/bin/jaotc \
+                 --slave /usr/bin/jlink jlink /usr/lib/jvm/java-16-amazon-corretto/bin/jlink \
+                 --slave /usr/bin/jmod jmod /usr/lib/jvm/java-16-amazon-corretto/bin/jmod \
+                 --slave /usr/bin/jhsdb jhsdb /usr/lib/jvm/java-16-amazon-corretto/bin/jhsdb \
+                 --slave /usr/bin/jar jar /usr/lib/jvm/java-16-amazon-corretto/bin/jar \
+                 --slave /usr/bin/jarsigner jarsigner /usr/lib/jvm/java-16-amazon-corretto/bin/jarsigner \
+                 --slave /usr/bin/javadoc javadoc /usr/lib/jvm/java-16-amazon-corretto/bin/javadoc \
+                 --slave /usr/bin/javap javap /usr/lib/jvm/java-16-amazon-corretto/bin/javap \
+                 --slave /usr/bin/jcmd jcmd /usr/lib/jvm/java-16-amazon-corretto/bin/jcmd \
+                 --slave /usr/bin/jconsole jconsole /usr/lib/jvm/java-16-amazon-corretto/bin/jconsole \
+                 --slave /usr/bin/jdb jdb /usr/lib/jvm/java-16-amazon-corretto/bin/jdb \
+                 --slave /usr/bin/jdeps jdeps /usr/lib/jvm/java-16-amazon-corretto/bin/jdeps \
+                 --slave /usr/bin/jdeprscan jdeprscan /usr/lib/jvm/java-16-amazon-corretto/bin/jdeprscan \
+                 --slave /usr/bin/jimage jimage /usr/lib/jvm/java-16-amazon-corretto/bin/jimage \
+                 --slave /usr/bin/jinfo jinfo /usr/lib/jvm/java-16-amazon-corretto/bin/jinfo \
+                 --slave /usr/bin/jmap jmap /usr/lib/jvm/java-16-amazon-corretto/bin/jmap \
+                 --slave /usr/bin/jps jps /usr/lib/jvm/java-16-amazon-corretto/bin/jps \
+                 --slave /usr/bin/jrunscript jrunscript /usr/lib/jvm/java-16-amazon-corretto/bin/jrunscript \
+                 --slave /usr/bin/jshell jshell /usr/lib/jvm/java-16-amazon-corretto/bin/jshell \
+                 --slave /usr/bin/jstack jstack /usr/lib/jvm/java-16-amazon-corretto/bin/jstack \
+                 --slave /usr/bin/jstat jstat /usr/lib/jvm/java-16-amazon-corretto/bin/jstat \
+                 --slave /usr/bin/jstatd jstatd /usr/lib/jvm/java-16-amazon-corretto/bin/jstatd \
+    && yum clean all
+
+ENV LANG C.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/java-16-amazon-corretto

--- a/16/slim/alpine/Dockerfile
+++ b/16/slim/alpine/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.12
+
+ARG version=16.0.0.36.1
+
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# The Corretto team will update this file but you may see a few days' delay.
+#
+# Slim:
+#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
+RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
+    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
+    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
+    apk add --no-cache amazon-corretto-16=$version-r0 binutils && \
+    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
+    apk del binutils amazon-corretto-16 && \
+    mkdir -p /usr/lib/jvm/ && \
+    mv /opt/corretto-slim /usr/lib/jvm/java-16-amazon-corretto && \
+    ln -sfn /usr/lib/jvm/java-16-amazon-corretto /usr/lib/jvm/default-jvm
+
+    
+
+ENV LANG C.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/16/slim/debian/Dockerfile
+++ b/16/slim/debian/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:buster-slim
+
+ARG version=16.0.0.36-1
+# In addition to installing the Amazon corretto, we also install
+# fontconfig. The folks who manage the docker hub's
+# official image library have found that font management
+# is a common usecase, and painpoint, and have
+# recommended that Java images include font support.
+#
+# See:
+#  https://github.com/docker-library/official-images/blob/master/test/tests/java-uimanager-font/container.java
+#
+# Slim:
+#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
+RUN set -ux \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl ca-certificates gnupg software-properties-common fontconfig \
+    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
+    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
+    && mkdir -p /usr/share/man/man1 \
+    && apt-get update \
+    && apt-get install -y java-16-amazon-corretto-jdk=1:$version binutils \
+    && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+            curl gnupg software-properties-common binutils java-16-amazon-corretto-jdk=1:$version \
+    && mkdir -p /usr/lib/jvm \
+    && mv /opt/corretto-slim /usr/lib/jvm/java-16-amazon-corretto \
+    && jdk_tools="java keytool rmid rmiregistry javac jaotc jlink jmod jhsdb jar jarsigner javadoc javap jcmd jconsole jdb jdeps jdeprscan jimage jinfo jmap jps jrunscript jshell jstack jstat jstatd serialver" \
+    && priority=$(echo "1${version}" | sed "s/\(\.\|-\)//g") \
+    && for i in ${jdk_tools}; do \
+          update-alternatives --install /usr/bin/$i $i /usr/lib/jvm/java-16-amazon-corretto/bin/$i ${priority}; \
+       done
+
+
+ENV LANG C.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/java-16-amazon-corretto

--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ aws ecr list-images --region us-west-2 --registry-id 489478819445 --repository-n
 * [8-alpine, 8u282-alpine, 8-alpine-full, 8-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
 * [8-alpine-jre, 8u282-alpine-jre](https://hub.docker.com/_/amazoncorretto)
 * [11-alpine, 11.0.10-alpine, 11-alpine-full, 11-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
-* [15, 15-al2-jdk, 15-al2-full](https://hub.docker.com/r/amazoncorretto/amazoncorretto)
-* [15-alpine, 15-alpine-full, 15-alpine-jdk](https://hub.docker.com/r/amazoncorretto/amazoncorretto)
+* [15, 15-al2-jdk, 15-al2-full](https://hub.docker.com/_/amazoncorretto)
+* [15-alpine, 15-alpine-full, 15-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
+* [16, 16-al2-jdk, 16-al2-full](https://hub.docker.com/_/amazoncorretto)
+* [16-alpine, 16-alpine-full, 16-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
 
 # Building
 To build the docker images, you can use the following command.
 
 ```
-docker build -t amazon-corretto-{major_version} -f ./{major_version}/{jdk|jre}/{al2|alpine|debian}/Dockerfile .
+docker build -t amazon-corretto-{major_version} -f ./{major_version}/{jdk|jre|slim}/{al2|alpine|debian}/Dockerfile .
 ```
 
 # Security

--- a/bin/update-dockerfiles.sh
+++ b/bin/update-dockerfiles.sh
@@ -64,6 +64,14 @@ while [ "$1" != "" ]; do
             shift
             CORRETTO_15_GENERIC_LINUX=$1
             ;;
+        --corretto-16-musl-linux )
+            shift
+            CORRETTO_16_MUSL_LINUX=$1
+            ;;
+        --corretto-16-generic-linux )
+            shift
+            CORRETTO_16_GENERIC_LINUX=$1
+            ;;
         --help )
             usage
             exit
@@ -84,6 +92,10 @@ if [ ! -z "${CORRETTO_15_MUSL_LINUX}" ]; then
     update_musl_linux ${CORRETTO_15_MUSL_LINUX} 15
 fi
 
+if [ ! -z "${CORRETTO_16_MUSL_LINUX}" ]; then
+    update_musl_linux ${CORRETTO_16_MUSL_LINUX} 16
+fi
+
 if [ ! -z "${CORRETTO_8_MUSL_LINUX}" ]; then
     sed -i "" "s/^ARG version=.*/ARG version=${CORRETTO_8_MUSL_LINUX}/g" ./8/jdk/alpine/Dockerfile
     sed -i "" "s/^ARG version=.*/ARG version=${CORRETTO_8_MUSL_LINUX}/g" ./8/jre/alpine/Dockerfile
@@ -100,6 +112,10 @@ fi
 
 if [ ! -z "${CORRETTO_15_GENERIC_LINUX}" ]; then
     update_generic_linux ${CORRETTO_15_GENERIC_LINUX} 15
+fi
+
+if [ ! -z "${CORRETTO_16_GENERIC_LINUX}" ]; then
+    update_generic_linux ${CORRETTO_16_GENERIC_LINUX} 16
 fi
 
 if [ ! -z "${CORRETTO_8_GENERIC_LINUX}" ]; then

--- a/test/test-image-corretto16-jdk.yaml
+++ b/test/test-image-corretto16-jdk.yaml
@@ -1,0 +1,17 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  env:
+    - key: LANG
+      value: C.UTF-8
+
+commandTests:
+  - name: "java command is registered using alternatives."
+    command: "java"
+    args: ["-version"]
+    expectedError: ["OpenJDK Runtime Environment Corretto-16.*"]
+
+  - name: "javac command is registered using alternatives."
+    command: "javac"
+    args: ["-version"]
+    expectedOutput: ["javac 16*"]

--- a/test/test-image-corretto16-slim.yaml
+++ b/test/test-image-corretto16-slim.yaml
@@ -1,0 +1,17 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  env:
+    - key: LANG
+      value: C.UTF-8
+
+commandTests:
+  - name: "java command is registered using alternatives."
+    command: "java"
+    args: ["-version"]
+    expectedError: ["OpenJDK Runtime Environment Corretto-16.*"]
+
+  - name: "javac command is registered using alternatives."
+    command: "javac"
+    args: ["-version"]
+    expectedOutput: ["javac 16*"]


### PR DESCRIPTION
*Description of changes:*
This PR add containers with recently released Corretto 16, for AL2, alpine and debian, as both full JDK and slim images.
Tags have been also updated to have these images in repositories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
