### PR TITLE
Update Corretto-11 to 11.0.11.9.1 and Corretto-8 to 8.292.10.1

### DIFF
--- a/.tags
+++ b/.tags
@@ -1,24 +1,24 @@
-Tags: 8, 8u282, 8u282-al2, 8-al2-full,8-al2-jdk, latest
+Tags: 8, 8u292, 8u292-al2, 8-al2-full,8-al2-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 11, 11.0.10, 11.0.10-al2, 11-al2-jdk, 11-al2-full
+Tags: 11, 11.0.11, 11.0.11-al2, 11-al2-jdk, 11-al2-full
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 8-alpine, 8u282-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine, 8u292-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64
 Directory: 8/jdk/alpine
 
-Tags: 8-alpine-jre, 8u282-alpine-jre
+Tags: 8-alpine-jre, 8u292-alpine-jre
 Architectures: amd64
 Directory: 8/jre/alpine
 
-Tags: 11-alpine, 11.0.10-alpine, 11-alpine-full, 11-alpine-jdk
+Tags: 11-alpine, 11.0.11-alpine, 11-alpine-full, 11-alpine-jdk
 Architectures: amd64
 Directory: 11/jdk/alpine
 
-Tags: 11-alpine-jre, 11.0.10-alpine-jre
+Tags: 11-alpine-jre, 11.0.11-alpine-jre
 Architectures: amd64
 Directory: 11/jre/alpine
 

--- a/11/jdk/al2/Dockerfile
+++ b/11/jdk/al2/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ARG version=11.0.10.9-1
+ARG version=11.0.11.9-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/11/jdk/alpine/Dockerfile
+++ b/11/jdk/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG version=11.0.10.9.1
+ARG version=11.0.11.9.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.

--- a/11/jdk/debian/Dockerfile
+++ b/11/jdk/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ARG version=11.0.10.9-1
+ARG version=11.0.11.9-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/11/jre/alpine/Dockerfile
+++ b/11/jre/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG version=11.0.10.9.1
+ARG version=11.0.11.9.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.

--- a/8/jdk/al2/Dockerfile
+++ b/8/jdk/al2/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ARG version=1.8.0_282.b08-1
+ARG version=1.8.0_292.b10-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG version=8.282.08.1
+ARG version=8.292.10.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.

--- a/8/jdk/debian/Dockerfile
+++ b/8/jdk/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ARG version=8.282.08-1
+ARG version=8.292.10-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/8/jre/alpine/Dockerfile
+++ b/8/jre/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG version=8.282.08.1
+ARG version=8.292.10.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ aws ecr list-images --region us-west-2 --registry-id 489478819445 --repository-n
 
 
 # Supported Tags
-* [8, 8u282, 8u282-al2, 8-al2-full,8-al2-jdk, latest](https://hub.docker.com/_/amazoncorretto)
-* [11, 11.0.10, 11.0.10-al2, 11-al2-jdk, 11-al2-full](https://hub.docker.com/_/amazoncorretto)
-* [8-alpine, 8u282-alpine, 8-alpine-full, 8-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
-* [8-alpine-jre, 8u282-alpine-jre](https://hub.docker.com/_/amazoncorretto)
-* [11-alpine, 11.0.10-alpine, 11-alpine-full, 11-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
+* [8, 8u292, 8u292-al2, 8-al2-full,8-al2-jdk, latest](https://hub.docker.com/_/amazoncorretto)
+* [11, 11.0.11, 11.0.11-al2, 11-al2-jdk, 11-al2-full](https://hub.docker.com/_/amazoncorretto)
+* [8-alpine, 8u292-alpine, 8-alpine-full, 8-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
+* [8-alpine-jre, 8u292-alpine-jre](https://hub.docker.com/_/amazoncorretto)
+* [11-alpine, 11.0.11-alpine, 11-alpine-full, 11-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
 * [15, 15-al2-jdk, 15-al2-full](https://hub.docker.com/_/amazoncorretto)
 * [15-alpine, 15-alpine-full, 15-alpine-jdk](https://hub.docker.com/_/amazoncorretto)
 * [16, 16-al2-jdk, 16-al2-full](https://hub.docker.com/_/amazoncorretto)


### PR DESCRIPTION
2021 Q2 release:

Update Corretto-11 to 11.0.11.9.1, including x64, aarch64 and alpine

Update Corretto-8 to 8.292.10.1, including x64, aarch64 and alpine