### PR TITLE
Update Corretto-16 to 16.0.1.9.1

### DIFF
--- a/.tags
+++ b/.tags
@@ -22,18 +22,18 @@ Tags: 11-alpine-jre, 11.0.11-alpine-jre
 Architectures: amd64
 Directory: 11/jre/alpine
 
-Tags: 16, 16.0.0, 16.0.0-al2, 16-al2-jdk, 16-al2-full
+Tags: 16, 16.0.1, 16.0.1-al2, 16-al2-jdk, 16-al2-full
 Architectures: amd64, arm64v8
 Directory: 16/jdk/al2
 
-Tags: 16-slim, 16.0.0-slim, 16.0.0-al2-slim
+Tags: 16-slim, 16.0.1, 16.0.1-al2-slim
 Architectures: amd64, arm64v8
 Directory: 16/slim/al2
 
-Tags: 16-alpine, 16.0.0-alpine, 16-alpine-full, 16-alpine-jdk
+Tags: 16-alpine, 16.0.1-alpine, 16-alpine-full, 16-alpine-jdk
 Architectures: amd64
 Directory: 16/jdk/alpine
 
-Tags: 16-alpine-slim, 16.0.0-alpine-slim
+Tags: 16-alpine-slim, 16.0.1-alpine-slim
 Architectures: amd64
 Directory: 16/slim/alpine

--- a/16/jdk/al2/Dockerfile
+++ b/16/jdk/al2/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ARG version=16.0.0.36-1
+ARG version=16.0.1.9-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/16/jdk/alpine/Dockerfile
+++ b/16/jdk/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG version=16.0.0.36.1
+ARG version=16.0.1.9.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.

--- a/16/jdk/debian/Dockerfile
+++ b/16/jdk/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ARG version=16.0.0.36-1
+ARG version=16.0.1.9-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/16/slim/al2/Dockerfile
+++ b/16/slim/al2/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazonlinux:2
 
-ARG version=16.0.0.36-1
+ARG version=16.0.1.9-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/16/slim/alpine/Dockerfile
+++ b/16/slim/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.12
 
-ARG version=16.0.0.36.1
+ARG version=16.0.1.9.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.

--- a/16/slim/debian/Dockerfile
+++ b/16/slim/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:buster-slim
 
-ARG version=16.0.0.36-1
+ARG version=16.0.1.9-1
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management

--- a/bin/update-dockerfiles.sh
+++ b/bin/update-dockerfiles.sh
@@ -20,6 +20,9 @@ update_musl_linux() {
     sed -i "" "s/${MAJOR_RELEASE}\.0\.[0-9]*-alpine/${jdk_version}-alpine/g" .tags
 
     sed -i "" "s/${MAJOR_RELEASE}\.0\.[0-9]*-alpine/${jdk_version}-alpine/g" README.md
+    if [ -d "./${MAJOR_RELEASE}/slim" ]; then
+        sed -i "" "s/ARG version=.*/ARG version=${CORRETTO_VERSION}/g" ./${MAJOR_RELEASE}/slim/alpine/Dockerfile
+    fi
 }
 
 update_generic_linux() {
@@ -36,6 +39,12 @@ update_generic_linux() {
 
     sed -i "" "s/${MAJOR_RELEASE}\.0\.[0-9]*,/${jdk_version},/g" README.md
     sed -i "" "s/${MAJOR_RELEASE}\.0\.[0-9]*-al2/${jdk_version}-al2/g" README.md
+    if [ -d "./${MAJOR_RELEASE}/slim" ]; then
+        sed -i "" "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/slim/al2/Dockerfile
+        sed -i "" "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/slim/debian/Dockerfile
+        sed -i "" "s/${MAJOR_RELEASE}\.0\.[0-9]*-slim,/${jdk_version},/g" .tags
+        sed -i "" "s/${MAJOR_RELEASE}\.0\.[0-9]*-slim,/${jdk_version},/g" README.md
+    fi
 
 }
 


### PR DESCRIPTION
Update Corretto 16 docker images to 16.0.1.9.1 for April 2021 release