### PR TITLE
Update security related yum packages

### DIFF
--- a/11/jdk/al2/Dockerfile
+++ b/11/jdk/al2/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
-    && yum update --security \
+    && yum update -y --security \
     && yum install -y java-11-amazon-corretto-devel-$version \
     && (find /usr/lib/jvm/java-11-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \

--- a/11/jdk/al2/Dockerfile
+++ b/11/jdk/al2/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
+    && yum update --security \
     && yum install -y java-11-amazon-corretto-devel-$version \
     && (find /usr/lib/jvm/java-11-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \

--- a/16/jdk/al2/Dockerfile
+++ b/16/jdk/al2/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
-    && yum update --security \
+    && yum update -y --security \
     && yum install -y java-16-amazon-corretto-devel-$version \
     && (find /usr/lib/jvm/java-16-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \

--- a/16/jdk/al2/Dockerfile
+++ b/16/jdk/al2/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
+    && yum update --security \
     && yum install -y java-16-amazon-corretto-devel-$version \
     && (find /usr/lib/jvm/java-16-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \

--- a/8/jdk/al2/Dockerfile
+++ b/8/jdk/al2/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
+    && yum update --security \
     && yum install -y java-1.8.0-amazon-corretto-devel-$version \
     && (find /usr/lib/jvm/java-1.8.0-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \

--- a/8/jdk/al2/Dockerfile
+++ b/8/jdk/al2/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
-    && yum update --security \
+    && yum update -y --security \
     && yum install -y java-1.8.0-amazon-corretto-devel-$version \
     && (find /usr/lib/jvm/java-1.8.0-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \


### PR DESCRIPTION
This gives Corretto ability to update security related packages by rebuilding docker image. the down side is update package installed in base layer can inflate the result docker image size. so we only doing it for security related updates.

*Issue #, if available:*

*Description of changes: Update security related yum packages for al2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
