### PR TITLE
Update aarch64 image for amazonlinux to 8.292.10.2

### DIFF
--- a/11/jdk/al2/Dockerfile
+++ b/11/jdk/al2/Dockerfile
@@ -22,7 +22,6 @@ RUN set -eux \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
-    && yum update -y --security \
     && yum install -y java-11-amazon-corretto-devel-$version \
     && (find /usr/lib/jvm/java-11-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \

--- a/16/jdk/al2/Dockerfile
+++ b/16/jdk/al2/Dockerfile
@@ -22,7 +22,6 @@ RUN set -eux \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
-    && yum update -y --security \
     && yum install -y java-16-amazon-corretto-devel-$version \
     && (find /usr/lib/jvm/java-16-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \

--- a/8/jdk/al2/Dockerfile
+++ b/8/jdk/al2/Dockerfile
@@ -22,7 +22,6 @@ RUN set -eux \
     && rm -r "$GNUPGHOME" corretto.key \
     && curl -fL -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
     && grep -q '^gpgcheck=1' /etc/yum.repos.d/corretto.repo \
-    && yum update -y --security \
     && yum install -y java-1.8.0-amazon-corretto-devel-$version \
     && (find /usr/lib/jvm/java-1.8.0-amazon-corretto -name src.zip -delete || true) \
     && yum install -y fontconfig \

--- a/8/jdk/al2/Dockerfile
+++ b/8/jdk/al2/Dockerfile
@@ -14,6 +14,7 @@ ARG version=1.8.0_292.b10-1
 # Comment = https://github.com/docker-library/official-images/pull/7459#issuecomment-592242757
 # PR = https://github.com/docker-library/official-images/pull/7459
 RUN set -eux \
+    && if [[ `arch` == 'aarch64' ]]; then version=1.8.0_292.b10-2; fi \
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fL -o corretto.key https://yum.corretto.aws/corretto.key \
     && gpg --batch --import corretto.key \


### PR DESCRIPTION
*Issue #, if available:*

Update amazonlinux aarch64 image to 8.292.10.2. 

This will also revert commit https://github.com/corretto/corretto-docker/commit/57ba304ff72b0c5a1e26b62435879a0a06869226
