### PR TITLE
Update AL2022 images to do better verification on RPMs

### DIFF
--- a/11/headful/al2022/Dockerfile
+++ b/11/headful/al2022/Dockerfile
@@ -2,9 +2,18 @@ FROM amazonlinux:2022
 
 ARG version=11.0.17.8-1
 RUN set -eux \
-    && yum install -y https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-headless-$version.amzn2022.$(uname -m).rpm https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-$version.amzn2022.$(uname -m).rpm \
+    && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2022 \
+    && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
+    && CORRETO_TEMP=$(mktemp -d) \
+    && pushd ${CORRETO_TEMP} \
+    && curl -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-headless-$version.amzn2022.$(uname -m).rpm -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-$version.amzn2022.$(uname -m).rpm \
+    && VERIFIED_COUNT=$(rpm -K ${CORRETO_TEMP}/*.rpm | grep -c ": digests signatures OK$") \
+    && [ 2 -eq ${VERIFIED_COUNT} ] \
+    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && popd \
     && rm -rf /usr/lib/jvm/java-11-amazon-corretto.$(uname -m)/lib/src.zip \
-    && yum clean all
+    && rm -rf ${CORRETO_TEMP} \
+    && dnf clean all
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/11/headless/al2022/Dockerfile
+++ b/11/headless/al2022/Dockerfile
@@ -2,9 +2,18 @@ FROM amazonlinux:2022
 
 ARG version=11.0.17.8-1
 RUN set -eux \
-    && yum install -y https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-headless-$version.amzn2022.$(uname -m).rpm \
+    && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2022 \
+    && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
+    && CORRETO_TEMP=$(mktemp -d) \
+    && pushd ${CORRETO_TEMP} \
+    && curl -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-headless-$version.amzn2022.$(uname -m).rpm \
+    && VERIFIED_COUNT=$(rpm -K ${CORRETO_TEMP}/*.rpm | grep -c ": digests signatures OK$") \
+    && [ 1 -eq ${VERIFIED_COUNT} ] \
+    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && popd \
     && rm -rf /usr/lib/jvm/java-11-amazon-corretto.$(uname -m)/lib/src.zip \
-    && yum clean all
+    && rm -rf ${CORRETO_TEMP} \
+    && dnf clean all
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/11/jdk/al2022/Dockerfile
+++ b/11/jdk/al2022/Dockerfile
@@ -1,10 +1,20 @@
 FROM amazonlinux:2022
 
 ARG version=11.0.17.8-1
+
 RUN set -eux \
-    && yum install -y https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-headless-$version.amzn2022.$(uname -m).rpm https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-$version.amzn2022.$(uname -m).rpm https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-devel-$version.amzn2022.$(uname -m).rpm\
+    && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2022 \
+    && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
+    && CORRETO_TEMP=$(mktemp -d) \
+    && pushd ${CORRETO_TEMP} \
+    && curl -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-headless-$version.amzn2022.$(uname -m).rpm -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-$version.amzn2022.$(uname -m).rpm -O  https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-11-amazon-corretto-devel-$version.amzn2022.$(uname -m).rpm \
+    && VERIFIED_COUNT=$(rpm -K ${CORRETO_TEMP}/*.rpm | grep -c ": digests signatures OK$") \
+    && [ 3 -eq ${VERIFIED_COUNT} ] \
+    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && popd \
     && rm -rf /usr/lib/jvm/java-11-amazon-corretto.$(uname -m)/lib/src.zip \
-    && yum clean all
+    && rm -rf ${CORRETO_TEMP} \
+    && dnf clean all
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/17/headful/al2022/Dockerfile
+++ b/17/headful/al2022/Dockerfile
@@ -1,12 +1,21 @@
 FROM amazonlinux:2022
 
 ARG version=17.0.5.8-1
-ARG packag_version=1
+ARG package_version=1
 
 RUN set -eux \
-    && yum install -y https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-headless-$version.amzn2022.${packag_version}.$(uname -m).rpm https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-$version.amzn2022.${packag_version}.$(uname -m).rpm \
+    && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2022 \
+    && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
+    && CORRETO_TEMP=$(mktemp -d) \
+    && pushd ${CORRETO_TEMP} \
+    && curl -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-headless-$version.amzn2022.${package_version}.$(uname -m).rpm -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-$version.amzn2022.${package_version}.$(uname -m).rpm \
+    && VERIFIED_COUNT=$(rpm -K ${CORRETO_TEMP}/*.rpm | grep -c ": digests signatures OK$") \
+    && [ 2 -eq ${VERIFIED_COUNT} ] \
+    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && popd \
     && rm -rf /usr/lib/jvm/java-17-amazon-corretto.$(uname -m)/lib/src.zip \
-    && yum clean all
+    && rm -rf ${CORRETO_TEMP} \
+    && dnf clean all
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/headless/al2022/Dockerfile
+++ b/17/headless/al2022/Dockerfile
@@ -1,12 +1,21 @@
 FROM amazonlinux:2022
 
 ARG version=17.0.5.8-1
-ARG packag_version=1
+ARG package_version=1
 
 RUN set -eux \
-    && yum install -y https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-headless-$version.amzn2022.${packag_version}.$(uname -m).rpm \
+    && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2022 \
+    && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
+    && CORRETO_TEMP=$(mktemp -d) \
+    && pushd ${CORRETO_TEMP} \
+    && curl -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-headless-$version.amzn2022.${package_version}.$(uname -m).rpm \
+    && VERIFIED_COUNT=$(rpm -K ${CORRETO_TEMP}/*.rpm | grep -c ": digests signatures OK$") \
+    && [ 1 -eq ${VERIFIED_COUNT} ] \
+    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && popd \
     && rm -rf /usr/lib/jvm/java-17-amazon-corretto.$(uname -m)/lib/src.zip \
-    && yum clean all
+    && rm -rf ${CORRETO_TEMP} \
+    && dnf clean all
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/jdk/al2022/Dockerfile
+++ b/17/jdk/al2022/Dockerfile
@@ -1,12 +1,21 @@
 FROM amazonlinux:2022
 
 ARG version=17.0.5.8-1
-ARG packag_version=1
+ARG package_version=1
 
 RUN set -eux \
-    && yum install -y https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-headless-$version.amzn2022.${packag_version}.$(uname -m).rpm https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-$version.amzn2022.${packag_version}.$(uname -m).rpm https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-devel-$version.amzn2022.${packag_version}.$(uname -m).rpm\
+    && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2022 \
+    && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
+    && CORRETO_TEMP=$(mktemp -d) \
+    && pushd ${CORRETO_TEMP} \
+    && curl -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-headless-$version.amzn2022.${package_version}.$(uname -m).rpm -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-$version.amzn2022.${package_version}.$(uname -m).rpm -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/java-17-amazon-corretto-devel-$version.amzn2022.${package_version}.$(uname -m).rpm \
+    && VERIFIED_COUNT=$(rpm -K ${CORRETO_TEMP}/*.rpm | grep -c ": digests signatures OK$") \
+    && [ 3 -eq ${VERIFIED_COUNT} ] \
+    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && popd \
     && rm -rf /usr/lib/jvm/java-17-amazon-corretto.$(uname -m)/lib/src.zip \
-    && yum clean all
+    && rm -rf ${CORRETO_TEMP} \
+    && dnf clean all
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/8/jdk/al2022/Dockerfile
+++ b/8/jdk/al2022/Dockerfile
@@ -2,11 +2,21 @@ FROM amazonlinux:2022
 
 ARG version=1.8.0_352.b08-1
 
+
 RUN set -eux \
     && export resouce_version=$(echo $version | tr '-' '.' | tr '_' '.'| tr -d "b" | awk -F. '{print $2"."$3"."$4"."$5"."$6}') \
-    && yum install -y https://corretto.aws/downloads/resources/${resouce_version}/java-1.8.0-amazon-corretto-$version.amzn2022.$(uname -m).rpm https://corretto.aws/downloads/resources/${resouce_version}/java-1.8.0-amazon-corretto-devel-$version.amzn2022.$(uname -m).rpm \
+    && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2022 \
+    && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
+    && CORRETO_TEMP=$(mktemp -d) \
+    && pushd ${CORRETO_TEMP} \
+    && curl -O https://corretto.aws/downloads/resources/${resouce_version}/java-1.8.0-amazon-corretto-$version.amzn2022.$(uname -m).rpm -O https://corretto.aws/downloads/resources/${resouce_version}/java-1.8.0-amazon-corretto-devel-$version.amzn2022.$(uname -m).rpm \
+    && VERIFIED_COUNT=$(rpm -K ${CORRETO_TEMP}/*.rpm | grep -c ": digests signatures OK$") \
+    && [ 2 -eq ${VERIFIED_COUNT} ] \
+    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && popd \
     && rm -rf /usr/lib/jvm/java-1.8.0-amazon-corretto.$(uname -m)/lib/src.zip \
-    && yum clean all
+    && rm -rf ${CORRETO_TEMP} \
+    && dnf clean all
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto

--- a/8/jre/al2022/Dockerfile
+++ b/8/jre/al2022/Dockerfile
@@ -4,10 +4,19 @@ ARG version=1.8.0_352.b08-1
 
 RUN set -eux \
     && export resouce_version=$(echo $version | tr '-' '.' | tr '_' '.'| tr -d "b" | awk -F. '{print $2"."$3"."$4"."$5"."$6}') \
-    && yum install -y https://corretto.aws/downloads/resources/${resouce_version}/java-1.8.0-amazon-corretto-$version.amzn2022.$(uname -m).rpm \
+    && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2022 \
+    && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
+    && CORRETO_TEMP=$(mktemp -d) \
+    && pushd ${CORRETO_TEMP} \
+    && curl -O https://corretto.aws/downloads/resources/${resouce_version}/java-1.8.0-amazon-corretto-$version.amzn2022.$(uname -m).rpm \
+    && VERIFIED_COUNT=$(rpm -K ${CORRETO_TEMP}/*.rpm | grep -c ": digests signatures OK$") \
+    && [ 1 -eq ${VERIFIED_COUNT} ] \
+    && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && alternatives --install /usr/lib/jvm/java-1.8.0-amazon-corretto java-1.8.0-amazon-corretto /usr/lib/jvm/java-1.8.0-amazon-corretto.$(uname -m) 100 \
+    && popd \
     && rm -rf /usr/lib/jvm/java-1.8.0-amazon-corretto.$(uname -m)/lib/src.zip \
-    && yum clean all
+    && rm -rf ${CORRETO_TEMP} \
+    && dnf clean all
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto/jre


### PR DESCRIPTION
Build images locally and tested the logic which will fail if the correct GPG key is not present.