### PR TITLE
Alpine 3.17

### DIFF
--- a/.github/workflows/verify-images.yml
+++ b/.github/workflows/verify-images.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ 8, 11, 17, 19 ]
-        os_version: ["3.13", "3.14", "3.15", "3.16" ]
+        os_version: ["3.13", "3.14", "3.15", "3.16", "3.17"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/11/jdk/alpine/3.17/Dockerfile
+++ b/11/jdk/alpine/3.17/Dockerfile
@@ -1,12 +1,9 @@
 FROM alpine:3.17
 
-ARG version=19.0.0.36.1
+ARG version=11.0.17.8.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-19=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-19 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-19-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-19-amazon-corretto /usr/lib/jvm/default-jvm
-
+    apk add --no-cache amazon-corretto-11=$version-r0
     
-
 ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
+
+    

--- a/17/jdk/alpine/3.17/Dockerfile
+++ b/17/jdk/alpine/3.17/Dockerfile
@@ -1,12 +1,9 @@
 FROM alpine:3.17
 
-ARG version=19.0.0.36.1
+ARG version=17.0.5.8.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-19=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-19 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-19-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-19-amazon-corretto /usr/lib/jvm/default-jvm
-
+    apk add --no-cache amazon-corretto-17=$version-r0
     
-
 ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
+
+    

--- a/17/slim/alpine/Dockerfile
+++ b/17/slim/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 ARG version=17.0.0.35.1
 

--- a/19/jdk/alpine/3.17/Dockerfile
+++ b/19/jdk/alpine/3.17/Dockerfile
@@ -1,12 +1,9 @@
 FROM alpine:3.17
 
-ARG version=19.0.0.36.1
+ARG version=19.0.1.10.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-19=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-19 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-19-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-19-amazon-corretto /usr/lib/jvm/default-jvm
-
+    apk add --no-cache amazon-corretto-19=$version-r0
     
-
 ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
+
+    

--- a/8/jdk/alpine/3.17/Dockerfile
+++ b/8/jdk/alpine/3.17/Dockerfile
@@ -1,12 +1,9 @@
 FROM alpine:3.17
 
-ARG version=19.0.0.36.1
+ARG version=8.352.08.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-19=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-19 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-19-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-19-amazon-corretto /usr/lib/jvm/default-jvm
-
+    apk add --no-cache amazon-corretto-8=$version-r0
     
-
 ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
+
+    

--- a/8/jre/alpine/3.17/Dockerfile
+++ b/8/jre/alpine/3.17/Dockerfile
@@ -1,12 +1,9 @@
 FROM alpine:3.17
 
-ARG version=19.0.0.36.1
+ARG version=8.352.08.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-19=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-19 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-19-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-19-amazon-corretto /usr/lib/jvm/default-jvm
+    apk add --no-cache amazon-corretto-8-jre=$version-r0
+    
+ENV LANG C.UTF-8
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 
     
-
-ENV LANG C.UTF-8
-ENV JAVA_HOME=/usr/lib/jvm/default-jvm
-ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/bin/apply-template.py
+++ b/bin/apply-template.py
@@ -13,7 +13,7 @@ def process_template_files(major_version, version, platform):
     input_parameter['MAJOR_VERSION'] = major_version
     if platform == 'alpine':
         # Update .github/workflows/verify-images.yml as well when alpine versions changes
-        os_versions = ['3.13', '3.14', '3.15', '3.16']
+        os_versions = ['3.13', '3.14', '3.15', '3.16', '3.17']
     try:
         shutil.rmtree(f"{major_version}/jdk/{platform}")
         shutil.rmtree(f"{major_version}/jre/{platform}")

--- a/bin/tag-generator.py
+++ b/bin/tag-generator.py
@@ -1,7 +1,7 @@
 import json
 
-DEFAULT_ALPINE_VERSION = '3.16'
-ALPINE_VERSIONS = ['3.13','3.14', '3.15', '3.16']
+DEFAULT_ALPINE_VERSION = '3.17'
+ALPINE_VERSIONS = ['3.13', '3.14', '3.15', '3.16', '3.17']
 
 LTS_VERSIONS = [ "8", "11", "17"]
 


### PR DESCRIPTION
*Issue #, if available:*

New alpine 3.17 was released. Docker Images need to be updated.

*Description of changes:*

Adding alpine 3.17 docker images for 8, 11, 17 and 19; updating existing 17 and 19 slim images to use alpine 3.17

Github actions passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
