### PR TITLE
Issue 156 Add Alpine 3.18 based images

### DIFF
--- a/11/jdk/alpine/3.18/Dockerfile
+++ b/11/jdk/alpine/3.18/Dockerfile
@@ -1,12 +1,9 @@
 FROM alpine:3.18
 
-ARG version=17.0.7.7.1
+ARG version=11.0.19.7.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-17 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-17-amazon-corretto /usr/lib/jvm/default-jvm
-
+    apk add --no-cache amazon-corretto-11=$version-r0
     
-
 ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
+
+    

--- a/17/jdk/alpine/3.18/Dockerfile
+++ b/17/jdk/alpine/3.18/Dockerfile
@@ -4,9 +4,6 @@ ARG version=17.0.7.7.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-17 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-17-amazon-corretto /usr/lib/jvm/default-jvm
-
+    apk add --no-cache amazon-corretto-17=$version-r0
     
-
 ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
+
+    

--- a/20/jdk/alpine/3.18/Dockerfile
+++ b/20/jdk/alpine/3.18/Dockerfile
@@ -1,12 +1,9 @@
 FROM alpine:3.18
 
-ARG version=17.0.7.7.1
+ARG version=20.0.1.9.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-17 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-17-amazon-corretto /usr/lib/jvm/default-jvm
-
+    apk add --no-cache amazon-corretto-20=$version-r0
     
-
 ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
+
+    

--- a/20/slim/alpine/Dockerfile
+++ b/20/slim/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 
 ARG version=20.0.1.9.1
 

--- a/8/jdk/alpine/3.18/Dockerfile
+++ b/8/jdk/alpine/3.18/Dockerfile
@@ -1,12 +1,9 @@
 FROM alpine:3.18
 
-ARG version=17.0.7.7.1
+ARG version=8.372.07.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-17 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-17-amazon-corretto /usr/lib/jvm/default-jvm
-
+    apk add --no-cache amazon-corretto-8=$version-r0
     
-
 ENV LANG C.UTF-8
+
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
+
+    

--- a/8/jre/alpine/3.18/Dockerfile
+++ b/8/jre/alpine/3.18/Dockerfile
@@ -1,12 +1,9 @@
 FROM alpine:3.18
 
-ARG version=17.0.7.7.1
+ARG version=8.372.07.1
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
 # The Corretto team will update this file but you may see a few days' delay.
-#
-# Slim:
-#   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
     tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
@@ -15,15 +12,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0 binutils && \
-    /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
-    apk del binutils amazon-corretto-17 && \
-    mkdir -p /usr/lib/jvm/ && \
-    mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto && \
-    ln -sfn /usr/lib/jvm/java-17-amazon-corretto /usr/lib/jvm/default-jvm
+    apk add --no-cache amazon-corretto-8-jre=$version-r0
+    
+ENV LANG C.UTF-8
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 
     
-
-ENV LANG C.UTF-8
-ENV JAVA_HOME=/usr/lib/jvm/default-jvm
-ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin


### PR DESCRIPTION
Provide images based on Alpine 3.18 so that downstream projects can benefit from using the latest version of Alpine Linux.
