### PR TITLE
Remove src.zip from Alpine images

### DIFF
--- a/11/jdk/alpine/3.15/Dockerfile
+++ b/11/jdk/alpine/3.15/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.15
 
 ARG version=11.0.19.7.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-11=$version-r0
-    
+    apk add --no-cache amazon-corretto-11=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-11-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/11/jdk/alpine/3.16/Dockerfile
+++ b/11/jdk/alpine/3.16/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.16
 
 ARG version=11.0.19.7.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-11=$version-r0
-    
+    apk add --no-cache amazon-corretto-11=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-11-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/11/jdk/alpine/3.17/Dockerfile
+++ b/11/jdk/alpine/3.17/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.17
 
 ARG version=11.0.19.7.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-11=$version-r0
-    
+    apk add --no-cache amazon-corretto-11=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-11-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/11/jdk/alpine/3.18/Dockerfile
+++ b/11/jdk/alpine/3.18/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.18
 
 ARG version=11.0.19.7.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-11=$version-r0
-    
+    apk add --no-cache amazon-corretto-11=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-11-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/17/jdk/alpine/3.15/Dockerfile
+++ b/17/jdk/alpine/3.15/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.15
 
 ARG version=17.0.7.7.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0
-    
+    apk add --no-cache amazon-corretto-17=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-17-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/17/jdk/alpine/3.16/Dockerfile
+++ b/17/jdk/alpine/3.16/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.16
 
 ARG version=17.0.7.7.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0
-    
+    apk add --no-cache amazon-corretto-17=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-17-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/17/jdk/alpine/3.17/Dockerfile
+++ b/17/jdk/alpine/3.17/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.17
 
 ARG version=17.0.7.7.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0
-    
+    apk add --no-cache amazon-corretto-17=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-17-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/17/jdk/alpine/3.18/Dockerfile
+++ b/17/jdk/alpine/3.18/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.18
 
 ARG version=17.0.7.7.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0
-    
+    apk add --no-cache amazon-corretto-17=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-17-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/20/jdk/alpine/3.15/Dockerfile
+++ b/20/jdk/alpine/3.15/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.15
 
 ARG version=20.0.1.9.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-20=$version-r0
-    
+    apk add --no-cache amazon-corretto-20=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-20-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/20/jdk/alpine/3.16/Dockerfile
+++ b/20/jdk/alpine/3.16/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.16
 
 ARG version=20.0.1.9.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-20=$version-r0
-    
+    apk add --no-cache amazon-corretto-20=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-20-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/20/jdk/alpine/3.17/Dockerfile
+++ b/20/jdk/alpine/3.17/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.17
 
 ARG version=20.0.1.9.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-20=$version-r0
-    
+    apk add --no-cache amazon-corretto-20=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-20-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/20/jdk/alpine/3.18/Dockerfile
+++ b/20/jdk/alpine/3.18/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.18
 
 ARG version=20.0.1.9.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-20=$version-r0
-    
+    apk add --no-cache amazon-corretto-20=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-20-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/8/jdk/alpine/3.15/Dockerfile
+++ b/8/jdk/alpine/3.15/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.15
 
 ARG version=8.372.07.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8=$version-r0
-    
+    apk add --no-cache amazon-corretto-8=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/8/jdk/alpine/3.16/Dockerfile
+++ b/8/jdk/alpine/3.16/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.16
 
 ARG version=8.372.07.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8=$version-r0
-    
+    apk add --no-cache amazon-corretto-8=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/8/jdk/alpine/3.17/Dockerfile
+++ b/8/jdk/alpine/3.17/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.17
 
 ARG version=8.372.07.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8=$version-r0
-    
+    apk add --no-cache amazon-corretto-8=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/8/jdk/alpine/3.18/Dockerfile
+++ b/8/jdk/alpine/3.18/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.18
 
 ARG version=8.372.07.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,11 +12,11 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8=$version-r0
-    
+    apk add --no-cache amazon-corretto-8=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
-
-    

--- a/8/jre/alpine/3.15/Dockerfile
+++ b/8/jre/alpine/3.15/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.15
 
 ARG version=8.372.07.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,10 +12,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8-jre=$version-r0
-    
+    apk add --no-cache amazon-corretto-8-jre=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
-
-    

--- a/8/jre/alpine/3.16/Dockerfile
+++ b/8/jre/alpine/3.16/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.16
 
 ARG version=8.372.07.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,10 +12,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8-jre=$version-r0
-    
+    apk add --no-cache amazon-corretto-8-jre=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
-
-    

--- a/8/jre/alpine/3.17/Dockerfile
+++ b/8/jre/alpine/3.17/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.17
 
 ARG version=8.372.07.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,10 +12,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8-jre=$version-r0
-    
+    apk add --no-cache amazon-corretto-8-jre=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
-
-    

--- a/8/jre/alpine/3.18/Dockerfile
+++ b/8/jre/alpine/3.18/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.18
 
 ARG version=8.372.07.1
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,10 +12,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8-jre=$version-r0
-    
+    apk add --no-cache amazon-corretto-8-jre=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
-
-    

--- a/templates/alpine.Dockerfile.template
+++ b/templates/alpine.Dockerfile.template
@@ -2,7 +2,7 @@ FROM alpine:{{OS_VERSION}}
 
 ARG version={{CORRETTO_VERSION}}
 
-# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently. 
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.
 RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
     echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
@@ -12,8 +12,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-{{MAJOR_VERSION}}{% if jre %}-jre{%endif%}=$version-r0
-    
+    apk add --no-cache amazon-corretto-{{MAJOR_VERSION}}{% if jre %}-jre{%endif%}=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-{{MAJOR_VERSION}}-amazon-corretto/lib/src.zip
+
+
 ENV LANG C.UTF-8
 {%if jre %}
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
@@ -21,4 +23,3 @@ ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
 {% endif %}
-    


### PR DESCRIPTION
Removing the src.zip on Alpine images to reduce image size. See https://github.com/corretto/corretto-docker/issues/139

Updated template and regenerated the images.