### PR TITLE
Bugfix: Move al2023 generic version updates out

### DIFF
--- a/bin/update-dockerfiles.sh
+++ b/bin/update-dockerfiles.sh
@@ -53,7 +53,6 @@ update_generic_linux() {
     jdk_build=$(echo ${CORRETTO_VERSION} | cut -d'.' -f4)
     corretto_version=$(echo ${CORRETTO_VERSION} | cut -d'.' -f5)
     ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2-generic/Dockerfile
-    ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2023-generic/Dockerfile
 
     if [[ "${LTS_VERSIONS[*]}" =~ ${MAJOR_RELEASE} ]]; then
         ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2023/Dockerfile
@@ -81,6 +80,17 @@ update_generic_linux() {
         ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}.${corretto_version}/g" ./${MAJOR_RELEASE}/slim/alpine/Dockerfile
         ${SED} "s/${MAJOR_RELEASE}\.0\.[0-9]*-slim,/${jdk_version},/g" README.md
     fi
+}
+
+update_al2023_generic_linux() {
+    CORRETTO_VERSION=$1
+    MAJOR_RELEASE=$2
+
+    jdk_version=$(echo ${CORRETTO_VERSION} | cut -d'.' -f1-3)
+    jdk_build=$(echo ${CORRETTO_VERSION} | cut -d'.' -f4)
+    corretto_version=$(echo ${CORRETTO_VERSION} | cut -d'.' -f5)
+
+    ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2023-generic/Dockerfile
 }
 
 while [ "$1" != "" ]; do
@@ -112,6 +122,7 @@ fi
 
 if [ ! -z "${CORRETTO_20_GENERIC_LINUX}" ]; then
     update_generic_linux ${CORRETTO_20_GENERIC_LINUX} 20
+    update_al2023_generic_linux ${CORRETTO_20_GENERIC_LINUX} 20
 fi
 
 if [ ! -z "${CORRETTO_8_GENERIC_LINUX}" ]; then

--- a/bin/update-dockerfiles.sh
+++ b/bin/update-dockerfiles.sh
@@ -53,7 +53,10 @@ update_generic_linux() {
     jdk_build=$(echo ${CORRETTO_VERSION} | cut -d'.' -f4)
     corretto_version=$(echo ${CORRETTO_VERSION} | cut -d'.' -f5)
     ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2-generic/Dockerfile
-    ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2023-generic/Dockerfile
+    if [[ -f ./${MAJOR_RELEASE}/jdk/al2023-generic/Dockerfile ]]
+    then
+        ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2023-generic/Dockerfile
+    fi
 
     if [[ "${LTS_VERSIONS[*]}" =~ ${MAJOR_RELEASE} ]]; then
         ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2023/Dockerfile

--- a/bin/update-dockerfiles.sh
+++ b/bin/update-dockerfiles.sh
@@ -53,6 +53,7 @@ update_generic_linux() {
     jdk_build=$(echo ${CORRETTO_VERSION} | cut -d'.' -f4)
     corretto_version=$(echo ${CORRETTO_VERSION} | cut -d'.' -f5)
     ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2-generic/Dockerfile
+    ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2023-generic/Dockerfile
 
     if [[ "${LTS_VERSIONS[*]}" =~ ${MAJOR_RELEASE} ]]; then
         ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2023/Dockerfile
@@ -80,17 +81,6 @@ update_generic_linux() {
         ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}.${corretto_version}/g" ./${MAJOR_RELEASE}/slim/alpine/Dockerfile
         ${SED} "s/${MAJOR_RELEASE}\.0\.[0-9]*-slim,/${jdk_version},/g" README.md
     fi
-}
-
-update_al2023_generic_linux() {
-    CORRETTO_VERSION=$1
-    MAJOR_RELEASE=$2
-
-    jdk_version=$(echo ${CORRETTO_VERSION} | cut -d'.' -f1-3)
-    jdk_build=$(echo ${CORRETTO_VERSION} | cut -d'.' -f4)
-    corretto_version=$(echo ${CORRETTO_VERSION} | cut -d'.' -f5)
-
-    ${SED} "s/ARG version=.*/ARG version=${jdk_version}.${jdk_build}-${corretto_version}/g" ./${MAJOR_RELEASE}/jdk/al2023-generic/Dockerfile
 }
 
 while [ "$1" != "" ]; do
@@ -122,7 +112,6 @@ fi
 
 if [ ! -z "${CORRETTO_20_GENERIC_LINUX}" ]; then
     update_generic_linux ${CORRETTO_20_GENERIC_LINUX} 20
-    update_al2023_generic_linux ${CORRETTO_20_GENERIC_LINUX} 20
 fi
 
 if [ ! -z "${CORRETTO_8_GENERIC_LINUX}" ]; then


### PR DESCRIPTION
### Note

Bug fix. al2023-generic was added in a function that would be executed in all versions, while it's supposed to be only in FR. https://github.com/corretto/corretto-docker/blob/8bd7e632b8362ae56b1d6cfc22e90ffc40a09ebc/bin/update-dockerfiles.sh#L56. It broke the workflow of updating docker file: https://github.com/corretto/corretto-docker/actions/runs/5743626153. 

Take the al2023 generic version update out from the . 

### Tests

Ran it locally with version updates in `version.json`, can see versions updated expectedly.