### PR TITLE
Add JVM memory percentage to better use container resources

### DIFF
--- a/11/headful/al2023/Dockerfile
+++ b/11/headful/al2023/Dockerfile
@@ -19,4 +19,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/11/headless/al2/Dockerfile
+++ b/11/headless/al2/Dockerfile
@@ -23,4 +23,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/yum.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/11/headless/al2023/Dockerfile
+++ b/11/headless/al2023/Dockerfile
@@ -19,4 +19,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/11/jdk/al2-generic/Dockerfile
+++ b/11/jdk/al2-generic/Dockerfile
@@ -29,4 +29,6 @@ RUN set -eux \
     && yum clean all
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/11/jdk/al2/Dockerfile
+++ b/11/jdk/al2/Dockerfile
@@ -23,4 +23,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/yum.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/11/jdk/al2023/Dockerfile
+++ b/11/jdk/al2023/Dockerfile
@@ -20,4 +20,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/11/jdk/alpine/3.15/Dockerfile
+++ b/11/jdk/alpine/3.15/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/11/jdk/alpine/3.16/Dockerfile
+++ b/11/jdk/alpine/3.16/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/11/jdk/alpine/3.17/Dockerfile
+++ b/11/jdk/alpine/3.17/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/11/jdk/alpine/3.18/Dockerfile
+++ b/11/jdk/alpine/3.18/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/11/jdk/debian/Dockerfile
+++ b/11/jdk/debian/Dockerfile
@@ -13,14 +13,16 @@ ARG version=11.0.20.9-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
+    curl ca-certificates gnupg software-properties-common fontconfig java-common \
     && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && mkdir -p /usr/share/man/man1 || true \
     && apt-get update \
     && apt-get install -y java-11-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+    curl gnupg software-properties-common
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/17/headful/al2/Dockerfile
+++ b/17/headful/al2/Dockerfile
@@ -23,4 +23,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/yum.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/headful/al2023/Dockerfile
+++ b/17/headful/al2023/Dockerfile
@@ -21,4 +21,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/headless/al2/Dockerfile
+++ b/17/headless/al2/Dockerfile
@@ -23,4 +23,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/yum.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/headless/al2023/Dockerfile
+++ b/17/headless/al2023/Dockerfile
@@ -21,4 +21,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/jdk/al2-generic/Dockerfile
+++ b/17/jdk/al2-generic/Dockerfile
@@ -29,4 +29,6 @@ RUN set -eux \
     && yum clean all
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/jdk/al2/Dockerfile
+++ b/17/jdk/al2/Dockerfile
@@ -3,26 +3,28 @@ FROM amazonlinux:2
 ARG version=17.0.8.8-1
 
 RUN set -eux \
-    && export resouce_version=$(echo $version | tr '-' '.') \
-    && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 \
-    && echo "localpkg_gpgcheck=1" >> /etc/yum.conf \
-    && CORRETO_TEMP=$(mktemp -d) \
-    && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-devel-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-jmods-$version.amzn2.1.$(uname -m).rpm") \
-    && for rpm in ${RPM_LIST[@]}; do \
-    curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
-    && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1 \
-    && if [[ ${rpm} != *jmods* ]]; then \
-      yum install -y $(yum deplist "${CORRETO_TEMP}/${rpm}" |grep provider | grep -vE "log4j-cve|corretto" | tr -s ' ' |cut -d ' ' -f 3 ); \
-      fi; \
-      done \
-    && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
-    && popd \
-    && (find /usr/lib/jvm/java-17-amazon-corretto.$(uname -m) -name src.zip -delete || true) \
-    && rm -rf ${CORRETO_TEMP} \
-    && yum clean all \
-    && rm -rf /var/cache/yum \
-    && sed -i '/localpkg_gpgcheck=1/d' /etc/yum.conf
+  && export resouce_version=$(echo $version | tr '-' '.') \
+  && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 \
+  && echo "localpkg_gpgcheck=1" >> /etc/yum.conf \
+  && CORRETO_TEMP=$(mktemp -d) \
+  && pushd ${CORRETO_TEMP} \
+  && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-devel-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-jmods-$version.amzn2.1.$(uname -m).rpm") \
+  && for rpm in ${RPM_LIST[@]}; do \
+  curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
+  && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1 \
+  && if [[ ${rpm} != *jmods* ]]; then \
+  yum install -y $(yum deplist "${CORRETO_TEMP}/${rpm}" |grep provider | grep -vE "log4j-cve|corretto" | tr -s ' ' |cut -d ' ' -f 3 ); \
+  fi; \
+  done \
+  && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
+  && popd \
+  && (find /usr/lib/jvm/java-17-amazon-corretto.$(uname -m) -name src.zip -delete || true) \
+  && rm -rf ${CORRETO_TEMP} \
+  && yum clean all \
+  && rm -rf /var/cache/yum \
+  && sed -i '/localpkg_gpgcheck=1/d' /etc/yum.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/jdk/al2023/Dockerfile
+++ b/17/jdk/al2023/Dockerfile
@@ -21,4 +21,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/jdk/alpine/3.15/Dockerfile
+++ b/17/jdk/alpine/3.15/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/17/jdk/alpine/3.16/Dockerfile
+++ b/17/jdk/alpine/3.16/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/17/jdk/alpine/3.17/Dockerfile
+++ b/17/jdk/alpine/3.17/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/17/jdk/alpine/3.18/Dockerfile
+++ b/17/jdk/alpine/3.18/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/17/jdk/debian/Dockerfile
+++ b/17/jdk/debian/Dockerfile
@@ -13,14 +13,16 @@ ARG version=17.0.8.8-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
+    curl ca-certificates gnupg software-properties-common fontconfig java-common \
     && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && mkdir -p /usr/share/man/man1 || true \
     && apt-get update \
     && apt-get install -y java-17-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+    curl gnupg software-properties-common
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/slim/al2/Dockerfile
+++ b/17/slim/al2/Dockerfile
@@ -35,33 +35,35 @@ RUN set -eux \
     && mkdir -p /usr/lib/jvm/ \
     && mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto \
     && alternatives --install /usr/bin/java java /usr/lib/jvm/java-17-amazon-corretto/bin/java $(echo "1${version}" | sed "s/\(\.\|-\)//g") \
-                  --slave /usr/bin/keytool keytool /usr/lib/jvm/java-17-amazon-corretto/bin/keytool \
-                  --slave /usr/bin/rmid rmid /usr/lib/jvm/java-17-amazon-corretto/bin/rmid \
-                  --slave /usr/bin/rmiregistry rmiregistry /usr/lib/jvm/java-17-amazon-corretto/bin/rmiregistry \
+    --slave /usr/bin/keytool keytool /usr/lib/jvm/java-17-amazon-corretto/bin/keytool \
+    --slave /usr/bin/rmid rmid /usr/lib/jvm/java-17-amazon-corretto/bin/rmid \
+    --slave /usr/bin/rmiregistry rmiregistry /usr/lib/jvm/java-17-amazon-corretto/bin/rmiregistry \
     && alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-17-amazon-corretto/bin/javac $(echo "1${version}" | sed "s/\(\.\|-\)//g") \
-                 --slave /usr/bin/jaotc jaotc /usr/lib/jvm/java-17-amazon-corretto/bin/jaotc \
-                 --slave /usr/bin/jlink jlink /usr/lib/jvm/java-17-amazon-corretto/bin/jlink \
-                 --slave /usr/bin/jmod jmod /usr/lib/jvm/java-17-amazon-corretto/bin/jmod \
-                 --slave /usr/bin/jhsdb jhsdb /usr/lib/jvm/java-17-amazon-corretto/bin/jhsdb \
-                 --slave /usr/bin/jar jar /usr/lib/jvm/java-17-amazon-corretto/bin/jar \
-                 --slave /usr/bin/jarsigner jarsigner /usr/lib/jvm/java-17-amazon-corretto/bin/jarsigner \
-                 --slave /usr/bin/javadoc javadoc /usr/lib/jvm/java-17-amazon-corretto/bin/javadoc \
-                 --slave /usr/bin/javap javap /usr/lib/jvm/java-17-amazon-corretto/bin/javap \
-                 --slave /usr/bin/jcmd jcmd /usr/lib/jvm/java-17-amazon-corretto/bin/jcmd \
-                 --slave /usr/bin/jconsole jconsole /usr/lib/jvm/java-17-amazon-corretto/bin/jconsole \
-                 --slave /usr/bin/jdb jdb /usr/lib/jvm/java-17-amazon-corretto/bin/jdb \
-                 --slave /usr/bin/jdeps jdeps /usr/lib/jvm/java-17-amazon-corretto/bin/jdeps \
-                 --slave /usr/bin/jdeprscan jdeprscan /usr/lib/jvm/java-17-amazon-corretto/bin/jdeprscan \
-                 --slave /usr/bin/jimage jimage /usr/lib/jvm/java-17-amazon-corretto/bin/jimage \
-                 --slave /usr/bin/jinfo jinfo /usr/lib/jvm/java-17-amazon-corretto/bin/jinfo \
-                 --slave /usr/bin/jmap jmap /usr/lib/jvm/java-17-amazon-corretto/bin/jmap \
-                 --slave /usr/bin/jps jps /usr/lib/jvm/java-17-amazon-corretto/bin/jps \
-                 --slave /usr/bin/jrunscript jrunscript /usr/lib/jvm/java-17-amazon-corretto/bin/jrunscript \
-                 --slave /usr/bin/jshell jshell /usr/lib/jvm/java-17-amazon-corretto/bin/jshell \
-                 --slave /usr/bin/jstack jstack /usr/lib/jvm/java-17-amazon-corretto/bin/jstack \
-                 --slave /usr/bin/jstat jstat /usr/lib/jvm/java-17-amazon-corretto/bin/jstat \
-                 --slave /usr/bin/jstatd jstatd /usr/lib/jvm/java-17-amazon-corretto/bin/jstatd \
+    --slave /usr/bin/jaotc jaotc /usr/lib/jvm/java-17-amazon-corretto/bin/jaotc \
+    --slave /usr/bin/jlink jlink /usr/lib/jvm/java-17-amazon-corretto/bin/jlink \
+    --slave /usr/bin/jmod jmod /usr/lib/jvm/java-17-amazon-corretto/bin/jmod \
+    --slave /usr/bin/jhsdb jhsdb /usr/lib/jvm/java-17-amazon-corretto/bin/jhsdb \
+    --slave /usr/bin/jar jar /usr/lib/jvm/java-17-amazon-corretto/bin/jar \
+    --slave /usr/bin/jarsigner jarsigner /usr/lib/jvm/java-17-amazon-corretto/bin/jarsigner \
+    --slave /usr/bin/javadoc javadoc /usr/lib/jvm/java-17-amazon-corretto/bin/javadoc \
+    --slave /usr/bin/javap javap /usr/lib/jvm/java-17-amazon-corretto/bin/javap \
+    --slave /usr/bin/jcmd jcmd /usr/lib/jvm/java-17-amazon-corretto/bin/jcmd \
+    --slave /usr/bin/jconsole jconsole /usr/lib/jvm/java-17-amazon-corretto/bin/jconsole \
+    --slave /usr/bin/jdb jdb /usr/lib/jvm/java-17-amazon-corretto/bin/jdb \
+    --slave /usr/bin/jdeps jdeps /usr/lib/jvm/java-17-amazon-corretto/bin/jdeps \
+    --slave /usr/bin/jdeprscan jdeprscan /usr/lib/jvm/java-17-amazon-corretto/bin/jdeprscan \
+    --slave /usr/bin/jimage jimage /usr/lib/jvm/java-17-amazon-corretto/bin/jimage \
+    --slave /usr/bin/jinfo jinfo /usr/lib/jvm/java-17-amazon-corretto/bin/jinfo \
+    --slave /usr/bin/jmap jmap /usr/lib/jvm/java-17-amazon-corretto/bin/jmap \
+    --slave /usr/bin/jps jps /usr/lib/jvm/java-17-amazon-corretto/bin/jps \
+    --slave /usr/bin/jrunscript jrunscript /usr/lib/jvm/java-17-amazon-corretto/bin/jrunscript \
+    --slave /usr/bin/jshell jshell /usr/lib/jvm/java-17-amazon-corretto/bin/jshell \
+    --slave /usr/bin/jstack jstack /usr/lib/jvm/java-17-amazon-corretto/bin/jstack \
+    --slave /usr/bin/jstat jstat /usr/lib/jvm/java-17-amazon-corretto/bin/jstat \
+    --slave /usr/bin/jstatd jstatd /usr/lib/jvm/java-17-amazon-corretto/bin/jstatd \
     && yum clean all
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/slim/alpine/Dockerfile
+++ b/17/slim/alpine/Dockerfile
@@ -22,8 +22,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto && \
     ln -sfn /usr/lib/jvm/java-17-amazon-corretto /usr/lib/jvm/default-jvm
 
-    
+
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/17/slim/debian/Dockerfile
+++ b/17/slim/debian/Dockerfile
@@ -15,7 +15,7 @@ ARG version=17.0.8.8-1
 RUN set -ux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig \
+    curl ca-certificates gnupg software-properties-common fontconfig \
     && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && mkdir -p /usr/share/man/man1 \
@@ -23,15 +23,17 @@ RUN set -ux \
     && apt-get install -y java-17-amazon-corretto-jdk=1:$version binutils \
     && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-            curl gnupg software-properties-common binutils java-17-amazon-corretto-jdk=1:$version \
+    curl gnupg software-properties-common binutils java-17-amazon-corretto-jdk=1:$version \
     && mkdir -p /usr/lib/jvm \
     && mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto \
     && jdk_tools="java keytool rmid rmiregistry javac jaotc jlink jmod jhsdb jar jarsigner javadoc javap jcmd jconsole jdb jdeps jdeprscan jimage jinfo jmap jps jrunscript jshell jstack jstat jstatd serialver" \
     && priority=$(echo "1${version}" | sed "s/\(\.\|-\)//g") \
     && for i in ${jdk_tools}; do \
-          update-alternatives --install /usr/bin/$i $i /usr/lib/jvm/java-17-amazon-corretto/bin/$i ${priority}; \
-       done
+    update-alternatives --install /usr/bin/$i $i /usr/lib/jvm/java-17-amazon-corretto/bin/$i ${priority}; \
+    done
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/20/jdk/al2-generic/Dockerfile
+++ b/20/jdk/al2-generic/Dockerfile
@@ -29,4 +29,6 @@ RUN set -eux \
     && yum clean all
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-20-amazon-corretto

--- a/20/jdk/al2023-generic/Dockerfile
+++ b/20/jdk/al2023-generic/Dockerfile
@@ -26,5 +26,7 @@ RUN set -eux \
     && dnf clean all
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-20-amazon-corretto
 

--- a/20/jdk/alpine/3.15/Dockerfile
+++ b/20/jdk/alpine/3.15/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/20/jdk/alpine/3.16/Dockerfile
+++ b/20/jdk/alpine/3.16/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/20/jdk/alpine/3.17/Dockerfile
+++ b/20/jdk/alpine/3.17/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/20/jdk/alpine/3.18/Dockerfile
+++ b/20/jdk/alpine/3.18/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/20/jdk/debian/Dockerfile
+++ b/20/jdk/debian/Dockerfile
@@ -13,14 +13,16 @@ ARG version=20.0.2.10-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
+    curl ca-certificates gnupg software-properties-common fontconfig java-common \
     && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && mkdir -p /usr/share/man/man1 || true \
     && apt-get update \
     && apt-get install -y java-20-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+    curl gnupg software-properties-common
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-20-amazon-corretto

--- a/20/slim/al2/Dockerfile
+++ b/20/slim/al2/Dockerfile
@@ -35,33 +35,35 @@ RUN set -eux \
     && mkdir -p /usr/lib/jvm/ \
     && mv /opt/corretto-slim /usr/lib/jvm/java-20-amazon-corretto \
     && alternatives --install /usr/bin/java java /usr/lib/jvm/java-20-amazon-corretto/bin/java $(echo "1${version}" | sed "s/\(\.\|-\)//g") \
-                  --slave /usr/bin/keytool keytool /usr/lib/jvm/java-20-amazon-corretto/bin/keytool \
-                  --slave /usr/bin/rmid rmid /usr/lib/jvm/java-20-amazon-corretto/bin/rmid \
-                  --slave /usr/bin/rmiregistry rmiregistry /usr/lib/jvm/java-20-amazon-corretto/bin/rmiregistry \
+    --slave /usr/bin/keytool keytool /usr/lib/jvm/java-20-amazon-corretto/bin/keytool \
+    --slave /usr/bin/rmid rmid /usr/lib/jvm/java-20-amazon-corretto/bin/rmid \
+    --slave /usr/bin/rmiregistry rmiregistry /usr/lib/jvm/java-20-amazon-corretto/bin/rmiregistry \
     && alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-20-amazon-corretto/bin/javac $(echo "1${version}" | sed "s/\(\.\|-\)//g") \
-                 --slave /usr/bin/jaotc jaotc /usr/lib/jvm/java-20-amazon-corretto/bin/jaotc \
-                 --slave /usr/bin/jlink jlink /usr/lib/jvm/java-20-amazon-corretto/bin/jlink \
-                 --slave /usr/bin/jmod jmod /usr/lib/jvm/java-20-amazon-corretto/bin/jmod \
-                 --slave /usr/bin/jhsdb jhsdb /usr/lib/jvm/java-20-amazon-corretto/bin/jhsdb \
-                 --slave /usr/bin/jar jar /usr/lib/jvm/java-20-amazon-corretto/bin/jar \
-                 --slave /usr/bin/jarsigner jarsigner /usr/lib/jvm/java-20-amazon-corretto/bin/jarsigner \
-                 --slave /usr/bin/javadoc javadoc /usr/lib/jvm/java-20-amazon-corretto/bin/javadoc \
-                 --slave /usr/bin/javap javap /usr/lib/jvm/java-20-amazon-corretto/bin/javap \
-                 --slave /usr/bin/jcmd jcmd /usr/lib/jvm/java-20-amazon-corretto/bin/jcmd \
-                 --slave /usr/bin/jconsole jconsole /usr/lib/jvm/java-20-amazon-corretto/bin/jconsole \
-                 --slave /usr/bin/jdb jdb /usr/lib/jvm/java-20-amazon-corretto/bin/jdb \
-                 --slave /usr/bin/jdeps jdeps /usr/lib/jvm/java-20-amazon-corretto/bin/jdeps \
-                 --slave /usr/bin/jdeprscan jdeprscan /usr/lib/jvm/java-20-amazon-corretto/bin/jdeprscan \
-                 --slave /usr/bin/jimage jimage /usr/lib/jvm/java-20-amazon-corretto/bin/jimage \
-                 --slave /usr/bin/jinfo jinfo /usr/lib/jvm/java-20-amazon-corretto/bin/jinfo \
-                 --slave /usr/bin/jmap jmap /usr/lib/jvm/java-20-amazon-corretto/bin/jmap \
-                 --slave /usr/bin/jps jps /usr/lib/jvm/java-20-amazon-corretto/bin/jps \
-                 --slave /usr/bin/jrunscript jrunscript /usr/lib/jvm/java-20-amazon-corretto/bin/jrunscript \
-                 --slave /usr/bin/jshell jshell /usr/lib/jvm/java-20-amazon-corretto/bin/jshell \
-                 --slave /usr/bin/jstack jstack /usr/lib/jvm/java-20-amazon-corretto/bin/jstack \
-                 --slave /usr/bin/jstat jstat /usr/lib/jvm/java-20-amazon-corretto/bin/jstat \
-                 --slave /usr/bin/jstatd jstatd /usr/lib/jvm/java-20-amazon-corretto/bin/jstatd \
+    --slave /usr/bin/jaotc jaotc /usr/lib/jvm/java-20-amazon-corretto/bin/jaotc \
+    --slave /usr/bin/jlink jlink /usr/lib/jvm/java-20-amazon-corretto/bin/jlink \
+    --slave /usr/bin/jmod jmod /usr/lib/jvm/java-20-amazon-corretto/bin/jmod \
+    --slave /usr/bin/jhsdb jhsdb /usr/lib/jvm/java-20-amazon-corretto/bin/jhsdb \
+    --slave /usr/bin/jar jar /usr/lib/jvm/java-20-amazon-corretto/bin/jar \
+    --slave /usr/bin/jarsigner jarsigner /usr/lib/jvm/java-20-amazon-corretto/bin/jarsigner \
+    --slave /usr/bin/javadoc javadoc /usr/lib/jvm/java-20-amazon-corretto/bin/javadoc \
+    --slave /usr/bin/javap javap /usr/lib/jvm/java-20-amazon-corretto/bin/javap \
+    --slave /usr/bin/jcmd jcmd /usr/lib/jvm/java-20-amazon-corretto/bin/jcmd \
+    --slave /usr/bin/jconsole jconsole /usr/lib/jvm/java-20-amazon-corretto/bin/jconsole \
+    --slave /usr/bin/jdb jdb /usr/lib/jvm/java-20-amazon-corretto/bin/jdb \
+    --slave /usr/bin/jdeps jdeps /usr/lib/jvm/java-20-amazon-corretto/bin/jdeps \
+    --slave /usr/bin/jdeprscan jdeprscan /usr/lib/jvm/java-20-amazon-corretto/bin/jdeprscan \
+    --slave /usr/bin/jimage jimage /usr/lib/jvm/java-20-amazon-corretto/bin/jimage \
+    --slave /usr/bin/jinfo jinfo /usr/lib/jvm/java-20-amazon-corretto/bin/jinfo \
+    --slave /usr/bin/jmap jmap /usr/lib/jvm/java-20-amazon-corretto/bin/jmap \
+    --slave /usr/bin/jps jps /usr/lib/jvm/java-20-amazon-corretto/bin/jps \
+    --slave /usr/bin/jrunscript jrunscript /usr/lib/jvm/java-20-amazon-corretto/bin/jrunscript \
+    --slave /usr/bin/jshell jshell /usr/lib/jvm/java-20-amazon-corretto/bin/jshell \
+    --slave /usr/bin/jstack jstack /usr/lib/jvm/java-20-amazon-corretto/bin/jstack \
+    --slave /usr/bin/jstat jstat /usr/lib/jvm/java-20-amazon-corretto/bin/jstat \
+    --slave /usr/bin/jstatd jstatd /usr/lib/jvm/java-20-amazon-corretto/bin/jstatd \
     && yum clean all
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-20-amazon-corretto

--- a/20/slim/alpine/Dockerfile
+++ b/20/slim/alpine/Dockerfile
@@ -22,8 +22,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     mv /opt/corretto-slim /usr/lib/jvm/java-20-amazon-corretto && \
     ln -sfn /usr/lib/jvm/java-20-amazon-corretto /usr/lib/jvm/default-jvm
 
-    
+
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/20/slim/debian/Dockerfile
+++ b/20/slim/debian/Dockerfile
@@ -15,7 +15,7 @@ ARG version=20.0.2.10-1
 RUN set -ux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig \
+    curl ca-certificates gnupg software-properties-common fontconfig \
     && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && mkdir -p /usr/share/man/man1 \
@@ -23,15 +23,17 @@ RUN set -ux \
     && apt-get install -y java-20-amazon-corretto-jdk=1:$version binutils \
     && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-            curl gnupg software-properties-common binutils java-20-amazon-corretto-jdk=1:$version \
+    curl gnupg software-properties-common binutils java-20-amazon-corretto-jdk=1:$version \
     && mkdir -p /usr/lib/jvm \
     && mv /opt/corretto-slim /usr/lib/jvm/java-20-amazon-corretto \
     && jdk_tools="java keytool rmid rmiregistry javac jaotc jlink jmod jhsdb jar jarsigner javadoc javap jcmd jconsole jdb jdeps jdeprscan jimage jinfo jmap jps jrunscript jshell jstack jstat jstatd serialver" \
     && priority=$(echo "1${version}" | sed "s/\(\.\|-\)//g") \
     && for i in ${jdk_tools}; do \
-          update-alternatives --install /usr/bin/$i $i /usr/lib/jvm/java-20-amazon-corretto/bin/$i ${priority}; \
-       done
+    update-alternatives --install /usr/bin/$i $i /usr/lib/jvm/java-20-amazon-corretto/bin/$i ${priority}; \
+    done
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-20-amazon-corretto

--- a/21/headful/al2023/Dockerfile
+++ b/21/headful/al2023/Dockerfile
@@ -21,4 +21,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto

--- a/21/headless/al2023/Dockerfile
+++ b/21/headless/al2023/Dockerfile
@@ -21,4 +21,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto

--- a/21/jdk/al2-generic/Dockerfile
+++ b/21/jdk/al2-generic/Dockerfile
@@ -29,4 +29,6 @@ RUN set -eux \
     && yum clean all
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto

--- a/21/jdk/al2023/Dockerfile
+++ b/21/jdk/al2023/Dockerfile
@@ -21,4 +21,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto

--- a/21/jdk/alpine/3.15/Dockerfile
+++ b/21/jdk/alpine/3.15/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/21/jdk/alpine/3.16/Dockerfile
+++ b/21/jdk/alpine/3.16/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/21/jdk/alpine/3.17/Dockerfile
+++ b/21/jdk/alpine/3.17/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/21/jdk/alpine/3.18/Dockerfile
+++ b/21/jdk/alpine/3.18/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/21/jdk/debian/Dockerfile
+++ b/21/jdk/debian/Dockerfile
@@ -13,14 +13,16 @@ ARG version=21.0.0.35-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
+    curl ca-certificates gnupg software-properties-common fontconfig java-common \
     && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && mkdir -p /usr/share/man/man1 || true \
     && apt-get update \
     && apt-get install -y java-21-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+    curl gnupg software-properties-common
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto

--- a/21/slim/al2/Dockerfile
+++ b/21/slim/al2/Dockerfile
@@ -35,33 +35,35 @@ RUN set -eux \
     && mkdir -p /usr/lib/jvm/ \
     && mv /opt/corretto-slim /usr/lib/jvm/java-21-amazon-corretto \
     && alternatives --install /usr/bin/java java /usr/lib/jvm/java-21-amazon-corretto/bin/java $(echo "1${version}" | sed "s/\(\.\|-\)//g") \
-                  --slave /usr/bin/keytool keytool /usr/lib/jvm/java-21-amazon-corretto/bin/keytool \
-                  --slave /usr/bin/rmid rmid /usr/lib/jvm/java-21-amazon-corretto/bin/rmid \
-                  --slave /usr/bin/rmiregistry rmiregistry /usr/lib/jvm/java-21-amazon-corretto/bin/rmiregistry \
+    --slave /usr/bin/keytool keytool /usr/lib/jvm/java-21-amazon-corretto/bin/keytool \
+    --slave /usr/bin/rmid rmid /usr/lib/jvm/java-21-amazon-corretto/bin/rmid \
+    --slave /usr/bin/rmiregistry rmiregistry /usr/lib/jvm/java-21-amazon-corretto/bin/rmiregistry \
     && alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-21-amazon-corretto/bin/javac $(echo "1${version}" | sed "s/\(\.\|-\)//g") \
-                 --slave /usr/bin/jaotc jaotc /usr/lib/jvm/java-21-amazon-corretto/bin/jaotc \
-                 --slave /usr/bin/jlink jlink /usr/lib/jvm/java-21-amazon-corretto/bin/jlink \
-                 --slave /usr/bin/jmod jmod /usr/lib/jvm/java-21-amazon-corretto/bin/jmod \
-                 --slave /usr/bin/jhsdb jhsdb /usr/lib/jvm/java-21-amazon-corretto/bin/jhsdb \
-                 --slave /usr/bin/jar jar /usr/lib/jvm/java-21-amazon-corretto/bin/jar \
-                 --slave /usr/bin/jarsigner jarsigner /usr/lib/jvm/java-21-amazon-corretto/bin/jarsigner \
-                 --slave /usr/bin/javadoc javadoc /usr/lib/jvm/java-21-amazon-corretto/bin/javadoc \
-                 --slave /usr/bin/javap javap /usr/lib/jvm/java-21-amazon-corretto/bin/javap \
-                 --slave /usr/bin/jcmd jcmd /usr/lib/jvm/java-21-amazon-corretto/bin/jcmd \
-                 --slave /usr/bin/jconsole jconsole /usr/lib/jvm/java-21-amazon-corretto/bin/jconsole \
-                 --slave /usr/bin/jdb jdb /usr/lib/jvm/java-21-amazon-corretto/bin/jdb \
-                 --slave /usr/bin/jdeps jdeps /usr/lib/jvm/java-21-amazon-corretto/bin/jdeps \
-                 --slave /usr/bin/jdeprscan jdeprscan /usr/lib/jvm/java-21-amazon-corretto/bin/jdeprscan \
-                 --slave /usr/bin/jimage jimage /usr/lib/jvm/java-21-amazon-corretto/bin/jimage \
-                 --slave /usr/bin/jinfo jinfo /usr/lib/jvm/java-21-amazon-corretto/bin/jinfo \
-                 --slave /usr/bin/jmap jmap /usr/lib/jvm/java-21-amazon-corretto/bin/jmap \
-                 --slave /usr/bin/jps jps /usr/lib/jvm/java-21-amazon-corretto/bin/jps \
-                 --slave /usr/bin/jrunscript jrunscript /usr/lib/jvm/java-21-amazon-corretto/bin/jrunscript \
-                 --slave /usr/bin/jshell jshell /usr/lib/jvm/java-21-amazon-corretto/bin/jshell \
-                 --slave /usr/bin/jstack jstack /usr/lib/jvm/java-21-amazon-corretto/bin/jstack \
-                 --slave /usr/bin/jstat jstat /usr/lib/jvm/java-21-amazon-corretto/bin/jstat \
-                 --slave /usr/bin/jstatd jstatd /usr/lib/jvm/java-21-amazon-corretto/bin/jstatd \
+    --slave /usr/bin/jaotc jaotc /usr/lib/jvm/java-21-amazon-corretto/bin/jaotc \
+    --slave /usr/bin/jlink jlink /usr/lib/jvm/java-21-amazon-corretto/bin/jlink \
+    --slave /usr/bin/jmod jmod /usr/lib/jvm/java-21-amazon-corretto/bin/jmod \
+    --slave /usr/bin/jhsdb jhsdb /usr/lib/jvm/java-21-amazon-corretto/bin/jhsdb \
+    --slave /usr/bin/jar jar /usr/lib/jvm/java-21-amazon-corretto/bin/jar \
+    --slave /usr/bin/jarsigner jarsigner /usr/lib/jvm/java-21-amazon-corretto/bin/jarsigner \
+    --slave /usr/bin/javadoc javadoc /usr/lib/jvm/java-21-amazon-corretto/bin/javadoc \
+    --slave /usr/bin/javap javap /usr/lib/jvm/java-21-amazon-corretto/bin/javap \
+    --slave /usr/bin/jcmd jcmd /usr/lib/jvm/java-21-amazon-corretto/bin/jcmd \
+    --slave /usr/bin/jconsole jconsole /usr/lib/jvm/java-21-amazon-corretto/bin/jconsole \
+    --slave /usr/bin/jdb jdb /usr/lib/jvm/java-21-amazon-corretto/bin/jdb \
+    --slave /usr/bin/jdeps jdeps /usr/lib/jvm/java-21-amazon-corretto/bin/jdeps \
+    --slave /usr/bin/jdeprscan jdeprscan /usr/lib/jvm/java-21-amazon-corretto/bin/jdeprscan \
+    --slave /usr/bin/jimage jimage /usr/lib/jvm/java-21-amazon-corretto/bin/jimage \
+    --slave /usr/bin/jinfo jinfo /usr/lib/jvm/java-21-amazon-corretto/bin/jinfo \
+    --slave /usr/bin/jmap jmap /usr/lib/jvm/java-21-amazon-corretto/bin/jmap \
+    --slave /usr/bin/jps jps /usr/lib/jvm/java-21-amazon-corretto/bin/jps \
+    --slave /usr/bin/jrunscript jrunscript /usr/lib/jvm/java-21-amazon-corretto/bin/jrunscript \
+    --slave /usr/bin/jshell jshell /usr/lib/jvm/java-21-amazon-corretto/bin/jshell \
+    --slave /usr/bin/jstack jstack /usr/lib/jvm/java-21-amazon-corretto/bin/jstack \
+    --slave /usr/bin/jstat jstat /usr/lib/jvm/java-21-amazon-corretto/bin/jstat \
+    --slave /usr/bin/jstatd jstatd /usr/lib/jvm/java-21-amazon-corretto/bin/jstatd \
     && yum clean all
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto

--- a/21/slim/alpine/Dockerfile
+++ b/21/slim/alpine/Dockerfile
@@ -22,8 +22,10 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     mv /opt/corretto-slim /usr/lib/jvm/java-21-amazon-corretto && \
     ln -sfn /usr/lib/jvm/java-21-amazon-corretto /usr/lib/jvm/default-jvm
 
-    
+
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/21/slim/debian/Dockerfile
+++ b/21/slim/debian/Dockerfile
@@ -15,7 +15,7 @@ ARG version=21.0.0.35-1
 RUN set -ux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig \
+    curl ca-certificates gnupg software-properties-common fontconfig \
     && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && mkdir -p /usr/share/man/man1 \
@@ -23,15 +23,17 @@ RUN set -ux \
     && apt-get install -y java-21-amazon-corretto-jdk=1:$version binutils \
     && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-            curl gnupg software-properties-common binutils java-21-amazon-corretto-jdk=1:$version \
+    curl gnupg software-properties-common binutils java-21-amazon-corretto-jdk=1:$version \
     && mkdir -p /usr/lib/jvm \
     && mv /opt/corretto-slim /usr/lib/jvm/java-21-amazon-corretto \
     && jdk_tools="java keytool rmid rmiregistry javac jaotc jlink jmod jhsdb jar jarsigner javadoc javap jcmd jconsole jdb jdeps jdeprscan jimage jinfo jmap jps jrunscript jshell jstack jstat jstatd serialver" \
     && priority=$(echo "1${version}" | sed "s/\(\.\|-\)//g") \
     && for i in ${jdk_tools}; do \
-          update-alternatives --install /usr/bin/$i $i /usr/lib/jvm/java-21-amazon-corretto/bin/$i ${priority}; \
-       done
+    update-alternatives --install /usr/bin/$i $i /usr/lib/jvm/java-21-amazon-corretto/bin/$i ${priority}; \
+    done
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto

--- a/8/jdk/al2-generic/Dockerfile
+++ b/8/jdk/al2-generic/Dockerfile
@@ -29,4 +29,6 @@ RUN set -eux \
     && yum clean all
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto

--- a/8/jdk/al2/Dockerfile
+++ b/8/jdk/al2/Dockerfile
@@ -24,4 +24,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/yum.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto

--- a/8/jdk/al2023/Dockerfile
+++ b/8/jdk/al2023/Dockerfile
@@ -23,4 +23,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto

--- a/8/jdk/alpine/3.15/Dockerfile
+++ b/8/jdk/alpine/3.15/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/8/jdk/alpine/3.16/Dockerfile
+++ b/8/jdk/alpine/3.16/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/8/jdk/alpine/3.17/Dockerfile
+++ b/8/jdk/alpine/3.17/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/8/jdk/alpine/3.18/Dockerfile
+++ b/8/jdk/alpine/3.18/Dockerfile
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/8/jdk/debian/Dockerfile
+++ b/8/jdk/debian/Dockerfile
@@ -13,14 +13,16 @@ ARG version=8.382.05-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
+    curl ca-certificates gnupg software-properties-common fontconfig java-common \
     && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
     && add-apt-repository 'deb https://apt.corretto.aws stable main' \
     && mkdir -p /usr/share/man/man1 || true \
     && apt-get update \
     && apt-get install -y java-1.8.0-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+    curl gnupg software-properties-common
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto

--- a/8/jre/al2/Dockerfile
+++ b/8/jre/al2/Dockerfile
@@ -25,4 +25,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/yum.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto/jre

--- a/8/jre/al2023/Dockerfile
+++ b/8/jre/al2023/Dockerfile
@@ -22,4 +22,6 @@ RUN set -eux \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto/jre

--- a/8/jre/alpine/3.15/Dockerfile
+++ b/8/jre/alpine/3.15/Dockerfile
@@ -17,5 +17,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre

--- a/8/jre/alpine/3.16/Dockerfile
+++ b/8/jre/alpine/3.16/Dockerfile
@@ -17,5 +17,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre

--- a/8/jre/alpine/3.17/Dockerfile
+++ b/8/jre/alpine/3.17/Dockerfile
@@ -17,5 +17,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre

--- a/8/jre/alpine/3.18/Dockerfile
+++ b/8/jre/alpine/3.18/Dockerfile
@@ -17,5 +17,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre

--- a/templates/alpine.Dockerfile.template
+++ b/templates/alpine.Dockerfile.template
@@ -17,6 +17,8 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
 
 
 ENV LANG C.UTF-8
+# JVM by default only uses 25% of container memory, since we are running only one JVM we can safely boost this with a bit of extra room for agents/sidecars.
+ENV JAVA_TOOL_OPTIONS "-XX:InitialRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
 {%if jre %}
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 {% else %}


### PR DESCRIPTION
*Issue #, if available:* No Issue

*Description of changes:* The JVM, by default, only uses 25% of the system's memory. Since the container is only the JVM, it makes more sense to extend this to use a larger part of the container to avoid memory thrashing. This will better utilize the container resources and make image resource management significantly easier.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
