### PR TITLE
Clean apt-get cache files to reduce container size by ~13mb

### DIFF
--- a/11/jdk/debian/Dockerfile
+++ b/11/jdk/debian/Dockerfile
@@ -20,7 +20,9 @@ RUN set -eux \
     && apt-get update \
     && apt-get install -y java-11-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+        curl gnupg software-properties-common \
+    && apt-get clean  \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/17/jdk/debian/Dockerfile
+++ b/17/jdk/debian/Dockerfile
@@ -20,7 +20,9 @@ RUN set -eux \
     && apt-get update \
     && apt-get install -y java-17-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+        curl gnupg software-properties-common \
+    && apt-get clean  \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/slim/debian/Dockerfile
+++ b/17/slim/debian/Dockerfile
@@ -24,6 +24,8 @@ RUN set -ux \
     && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
             curl gnupg software-properties-common binutils java-17-amazon-corretto-jdk=1:$version \
+    && apt-get clean  \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /usr/lib/jvm \
     && mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto \
     && jdk_tools="java keytool rmid rmiregistry javac jaotc jlink jmod jhsdb jar jarsigner javadoc javap jcmd jconsole jdb jdeps jdeprscan jimage jinfo jmap jps jrunscript jshell jstack jstat jstatd serialver" \

--- a/21/jdk/debian/Dockerfile
+++ b/21/jdk/debian/Dockerfile
@@ -21,6 +21,8 @@ RUN set -eux \
     && apt-get install -y java-21-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
         curl gnupg software-properties-common
+    && apt-get clean  \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto

--- a/21/slim/debian/Dockerfile
+++ b/21/slim/debian/Dockerfile
@@ -24,6 +24,8 @@ RUN set -ux \
     && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
             curl gnupg software-properties-common binutils java-21-amazon-corretto-jdk=1:$version \
+    && apt-get clean  \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /usr/lib/jvm \
     && mv /opt/corretto-slim /usr/lib/jvm/java-21-amazon-corretto \
     && jdk_tools="java keytool rmid rmiregistry javac jaotc jlink jmod jhsdb jar jarsigner javadoc javap jcmd jconsole jdb jdeps jdeprscan jimage jinfo jmap jps jrunscript jshell jstack jstat jstatd serialver" \

--- a/8/jdk/debian/Dockerfile
+++ b/8/jdk/debian/Dockerfile
@@ -20,7 +20,9 @@ RUN set -eux \
     && apt-get update \
     && apt-get install -y java-1.8.0-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+        curl gnupg software-properties-common \
+    && apt-get clean  \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto


### PR DESCRIPTION
*Issue #, if available:*
Apt cache files are left in the final built container

*Description of changes:*
run `apt-get clean` and `rm -rf /var/lib/apt/lists/*` to clear cache

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
