### PR TITLE
Make AL2023 images the default for Corretto 22+

### DIFF
--- a/.tags
+++ b/.tags
@@ -1,139 +1,196 @@
-Tags: 8, 8u382, 8u382-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u382-al2-generic, 8-al2-generic-jdk, latest
+Tags: 8, 8u402, 8u402-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u402-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2-generic
 
-Tags: 8-al2023, 8u382-al2023, 8-al2023-jdk
+Tags: 8-al2023, 8u402-al2023, 8-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2023-jre, 8u382-al2023-jre
+Tags: 8-al2023-jre, 8u402-al2023-jre
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2-native-jre, 8u382-al2-native-jre
+Tags: 8-al2-native-jre, 8u402-al2-native-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/al2
 
-Tags: 8-al2-native-jdk, 8u382-al2-native-jdk
+Tags: 8-al2-native-jdk, 8u402-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 8-alpine3.16, 8u382-alpine3.16, 8-alpine3.16-full, 8-alpine3.16-jdk
+Tags: 8-alpine3.16, 8u402-alpine3.16, 8-alpine3.16-full, 8-alpine3.16-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.16
 
-Tags: 8-alpine3.16-jre, 8u382-alpine3.16-jre
+Tags: 8-alpine3.16-jre, 8u402-alpine3.16-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.16
 
-Tags: 8-alpine3.17, 8u382-alpine3.17, 8-alpine3.17-full, 8-alpine3.17-jdk
+Tags: 8-alpine3.17, 8u402-alpine3.17, 8-alpine3.17-full, 8-alpine3.17-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.17
 
-Tags: 8-alpine3.17-jre, 8u382-alpine3.17-jre
+Tags: 8-alpine3.17-jre, 8u402-alpine3.17-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.17
 
-Tags: 8-alpine3.18, 8u382-alpine3.18, 8-alpine3.18-full, 8-alpine3.18-jdk, 8-alpine, 8u382-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine3.18, 8u402-alpine3.18, 8-alpine3.18-full, 8-alpine3.18-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.18
 
-Tags: 8-alpine3.18-jre, 8u382-alpine3.18-jre, 8-alpine-jre, 8u382-alpine-jre
+Tags: 8-alpine3.18-jre, 8u402-alpine3.18-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.18
 
-Tags: 11, 11.0.20, 11.0.20-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.20-al2-generic, 11-al2-generic-jdk
+Tags: 8-alpine3.19, 8u402-alpine3.19, 8-alpine3.19-full, 8-alpine3.19-jdk, 8-alpine, 8u402-alpine, 8-alpine-full, 8-alpine-jdk
+Architectures: amd64, arm64v8
+Directory: 8/jdk/alpine/3.19
+
+Tags: 8-alpine3.19-jre, 8u402-alpine3.19-jre, 8-alpine-jre, 8u402-alpine-jre
+Architectures: amd64, arm64v8
+Directory: 8/jre/alpine/3.19
+
+Tags: 11, 11.0.22, 11.0.22-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.22-al2-generic, 11-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2-generic
 
-Tags: 11-al2023, 11.0.20-al2023, 11-al2023-jdk
+Tags: 11-al2023, 11.0.22-al2023, 11-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2023
 
-Tags: 11-al2023-headless, 11.0.20-al2023-headless
+Tags: 11-al2023-headless, 11.0.22-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2023
 
-Tags: 11-al2023-headful, 11.0.20-al2023-headful
+Tags: 11-al2023-headful, 11.0.22-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 11/headful/al2023
 
-Tags: 11-al2-native-headless, 11.0.20-al2-native-headless
+Tags: 11-al2-native-headless, 11.0.22-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2
 
-Tags: 11-al2-native-jdk, 11.0.20-al2-native-jdk
+Tags: 11-al2-native-jdk, 11.0.22-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 11-alpine3.16, 11.0.20-alpine3.16, 11-alpine3.16-full, 11-alpine3.16-jdk
+Tags: 11-alpine3.16, 11.0.22-alpine3.16, 11-alpine3.16-full, 11-alpine3.16-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.16
 
-Tags: 11-alpine3.17, 11.0.20-alpine3.17, 11-alpine3.17-full, 11-alpine3.17-jdk
+Tags: 11-alpine3.17, 11.0.22-alpine3.17, 11-alpine3.17-full, 11-alpine3.17-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.17
 
-Tags: 11-alpine3.18, 11.0.20-alpine3.18, 11-alpine3.18-full, 11-alpine3.18-jdk, 11-alpine, 11.0.20-alpine, 11-alpine-full, 11-alpine-jdk
+Tags: 11-alpine3.18, 11.0.22-alpine3.18, 11-alpine3.18-full, 11-alpine3.18-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.18
 
-Tags: 17, 17.0.8, 17.0.8-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.8-al2-generic, 17-al2-generic-jdk
+Tags: 11-alpine3.19, 11.0.22-alpine3.19, 11-alpine3.19-full, 11-alpine3.19-jdk, 11-alpine, 11.0.22-alpine, 11-alpine-full, 11-alpine-jdk
+Architectures: amd64, arm64v8
+Directory: 11/jdk/alpine/3.19
+
+Tags: 17, 17.0.10, 17.0.10-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.10-al2-generic, 17-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2-generic
 
-Tags: 17-al2023, 17.0.8-al2023, 17-al2023-jdk
+Tags: 17-al2023, 17.0.10-al2023, 17-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2023
 
-Tags: 17-al2023-headless, 17.0.8-al2023-headless
+Tags: 17-al2023-headless, 17.0.10-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2023
 
-Tags: 17-al2023-headful, 17.0.8-al2023-headful
+Tags: 17-al2023-headful, 17.0.10-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2023
 
-Tags: 17-al2-native-headless, 17.0.8-al2-native-headless
+Tags: 17-al2-native-headless, 17.0.10-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2
 
-Tags: 17-al2-native-headful, 17.0.8-al2-native-headful
+Tags: 17-al2-native-headful, 17.0.10-al2-native-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2
 
-Tags: 17-al2-native-jdk, 17.0.8-al2-native-jdk
+Tags: 17-al2-native-jdk, 17.0.10-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2
 
-Tags: 17-alpine3.16, 17.0.8-alpine3.16, 17-alpine3.16-full, 17-alpine3.16-jdk
+Tags: 17-alpine3.16, 17.0.10-alpine3.16, 17-alpine3.16-full, 17-alpine3.16-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.16
 
-Tags: 17-alpine3.17, 17.0.8-alpine3.17, 17-alpine3.17-full, 17-alpine3.17-jdk
+Tags: 17-alpine3.17, 17.0.10-alpine3.17, 17-alpine3.17-full, 17-alpine3.17-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.17
 
-Tags: 17-alpine3.18, 17.0.8-alpine3.18, 17-alpine3.18-full, 17-alpine3.18-jdk, 17-alpine, 17.0.8-alpine, 17-alpine-full, 17-alpine-jdk
+Tags: 17-alpine3.18, 17.0.10-alpine3.18, 17-alpine3.18-full, 17-alpine3.18-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.18
 
-Tags: 20, 20.0.2, 20.0.2-al2, 20-al2-full, 20-al2-jdk, 20-al2-generic, 20.0.2-al2-generic, 20-al2-generic-jdk
+Tags: 17-alpine3.19, 17.0.10-alpine3.19, 17-alpine3.19-full, 17-alpine3.19-jdk, 17-alpine, 17.0.10-alpine, 17-alpine-full, 17-alpine-jdk
 Architectures: amd64, arm64v8
-Directory: 20/jdk/al2-generic
+Directory: 17/jdk/alpine/3.19
 
-Tags: 20-al2023-generic, 20.0.2-al2023-generic, 20-al2023-generic-jdk
+Tags: 21, 21.0.2, 21.0.2-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.2-al2-generic, 21-al2-generic-jdk
 Architectures: amd64, arm64v8
-Directory: 20/jdk/al2023-generic
+Directory: 21/jdk/al2-generic
 
-Tags: 20-alpine3.16, 20.0.2-alpine3.16, 20-alpine3.16-full, 20-alpine3.16-jdk
+Tags: 21-al2023, 21.0.2-al2023, 21-al2023-jdk
 Architectures: amd64, arm64v8
-Directory: 20/jdk/alpine/3.16
+Directory: 21/jdk/al2023
 
-Tags: 20-alpine3.17, 20.0.2-alpine3.17, 20-alpine3.17-full, 20-alpine3.17-jdk
+Tags: 21-al2023-headless, 21.0.2-al2023-headless
 Architectures: amd64, arm64v8
-Directory: 20/jdk/alpine/3.17
+Directory: 21/headless/al2023
 
-Tags: 20-alpine3.18, 20.0.2-alpine3.18, 20-alpine3.18-full, 20-alpine3.18-jdk, 20-alpine, 20.0.2-alpine, 20-alpine-full, 20-alpine-jdk
+Tags: 21-al2023-headful, 21.0.2-al2023-headful
 Architectures: amd64, arm64v8
-Directory: 20/jdk/alpine/3.18
+Directory: 21/headful/al2023
+
+Tags: 21-alpine3.16, 21.0.2-alpine3.16, 21-alpine3.16-full, 21-alpine3.16-jdk
+Architectures: amd64, arm64v8
+Directory: 21/jdk/alpine/3.16
+
+Tags: 21-alpine3.17, 21.0.2-alpine3.17, 21-alpine3.17-full, 21-alpine3.17-jdk
+Architectures: amd64, arm64v8
+Directory: 21/jdk/alpine/3.17
+
+Tags: 21-alpine3.18, 21.0.2-alpine3.18, 21-alpine3.18-full, 21-alpine3.18-jdk
+Architectures: amd64, arm64v8
+Directory: 21/jdk/alpine/3.18
+
+Tags: 21-alpine3.19, 21.0.2-alpine3.19, 21-alpine3.19-full, 21-alpine3.19-jdk, 21-alpine, 21.0.2-alpine, 21-alpine-full, 21-alpine-jdk
+Architectures: amd64, arm64v8
+Directory: 21/jdk/alpine/3.19
+
+Tags: 22-al2023, 22.0.0-al2023, 22-al2023-jdk, 22, 22-jdk
+Architectures: amd64, arm64v8
+Directory: 22/jdk/al2023
+
+Tags: 22-al2023-headless, 22.0.0-al2023-headless, 22-headless
+Architectures: amd64, arm64v8
+Directory: 22/headless/al2023
+
+Tags: 22-al2023-headful, 22.0.0-al2023-headful, 22-headful
+Architectures: amd64, arm64v8
+Directory: 22/headful/al2023
+
+Tags: 22-alpine3.16, 22.0.0-alpine3.16, 22-alpine3.16-full, 22-alpine3.16-jdk
+Architectures: amd64, arm64v8
+Directory: 22/jdk/alpine/3.16
+
+Tags: 22-alpine3.17, 22.0.0-alpine3.17, 22-alpine3.17-full, 22-alpine3.17-jdk
+Architectures: amd64, arm64v8
+Directory: 22/jdk/alpine/3.17
+
+Tags: 22-alpine3.18, 22.0.0-alpine3.18, 22-alpine3.18-full, 22-alpine3.18-jdk
+Architectures: amd64, arm64v8
+Directory: 22/jdk/alpine/3.18
+
+Tags: 22-alpine3.19, 22.0.0-alpine3.19, 22-alpine3.19-full, 22-alpine3.19-jdk, 22-alpine, 22.0.0-alpine, 22-alpine-full, 22-alpine-jdk
+Architectures: amd64, arm64v8
+Directory: 22/jdk/alpine/3.19
+

--- a/bin/tag-generator.py
+++ b/bin/tag-generator.py
@@ -3,44 +3,49 @@ import json
 DEFAULT_ALPINE_VERSION = '3.19'
 ALPINE_VERSIONS = ['3.16', '3.17', '3.18', '3.19']
 
-LTS_VERSIONS = [ "8", "11", "17", "21"]
-FR_VERSIONS = [ "22" ]
 def generate_tags(key, version):
     update = version.split('.')[1] if (key == '8') else version.split('.')[2]
     expanded_version = f"{key}u{update}" if (key == '8') else f"{key}.0.{update}"
 
     al2023_tags = [f"{key}-al2023",  f"{expanded_version}-al2023" ,f"{key}-al2023-jdk"]
-    al2023_generic_tags = [f"{key}-al2023-generic", f"{expanded_version}-al2023-generic", f"{key}-al2023-generic-jdk"]
+    al2023_headless_tags = [f"{key}-al2023-headless",  f"{expanded_version}-al2023-headless"]
+    al2023_headful_tags = [f"{key}-al2023-headful",  f"{expanded_version}-al2023-headful"]
+    # These only apply for Corretto8 which does not have the same modulare packages as 11+
+    al2023_8_tags = [f"{key}-al2023-jre",  f"{expanded_version}-al2023-jre"]
+
     if int(key) <= 21:
         al2_tags = [f"{key}", f"{expanded_version}", f"{expanded_version}-al2", f"{key}-al2-full", f"{key}-al2-jdk", f"{key}-al2-generic", f"{expanded_version}-al2-generic", f"{key}-al2-generic-jdk"]
+        if key == '8':
+            al2_tags.append('latest')
         print("Tags: " + ", ".join(al2_tags) + "")
         print("Architectures: amd64, arm64v8")
         print(f"Directory: {key}/jdk/al2-generic\n")
-    else:
-        al2_tags = []
+
+    # Starting with Corretto 22 AL2 based images are not longer vended and AL2023 will be the
+    # default base OS until the next AL version is GA.
+    if int(key) >= 22:
+        al2023_tags.append(f"{key}")
+        al2023_tags.append(f"{key}-jdk")
+        al2023_headless_tags.append(f"{key}-headless")
+        al2023_headful_tags.append(f"{key}-headful")
+
+    print("Tags: " + ", ".join(al2023_tags) + "")
+    print("Architectures: amd64, arm64v8")
+    print(f"Directory: {key}/jdk/al2023\n")
     if key == '8':
-        al2_tags.append('latest')
-
-
-    if key in LTS_VERSIONS or key in FR_VERSIONS:
-        print("Tags: " + ", ".join(al2023_tags) + "")
+        print("Tags: " + ", ".join(al2023_8_tags))
         print("Architectures: amd64, arm64v8")
         print(f"Directory: {key}/jdk/al2023\n")
-        if key == '8':
-            print("Tags: " + ", ".join([f"{key}-al2023-jre",  f"{expanded_version}-al2023-jre"]))
-            print("Architectures: amd64, arm64v8")
-            print(f"Directory: {key}/jdk/al2023\n")
-        else:
-            print("Tags: " + ", ".join([f"{key}-al2023-headless",  f"{expanded_version}-al2023-headless"]))
-            print("Architectures: amd64, arm64v8")
-            print(f"Directory: {key}/headless/al2023\n")
+    else:
+        print("Tags: " + ", ".join(al2023_headless_tags))
+        print("Architectures: amd64, arm64v8")
+        print(f"Directory: {key}/headless/al2023\n")
 
-            print("Tags: " + ", ".join([f"{key}-al2023-headful",  f"{expanded_version}-al2023-headful"]))
-            print("Architectures: amd64, arm64v8")
-            print(f"Directory: {key}/headful/al2023\n")
+        print("Tags: " + ", ".join(al2023_headful_tags))
+        print("Architectures: amd64, arm64v8")
+        print(f"Directory: {key}/headful/al2023\n")
 
-
-    # For LTS versions with modular AmazonLinux packages we want to tag those images
+    # For LTS versions with modular AmazonLinux 2 packages we want to tag those images
     native_package_modifier="al2-native-"
     if key in ["17"]:
         for image_type in ['headless', 'headful', 'jdk']:


### PR DESCRIPTION
Diff between old and new tags

```
169c169
< Tags: 22-al2023, 22.0.0-al2023, 22-al2023-jdk
---
> Tags: 22-al2023, 22.0.0-al2023, 22-al2023-jdk, 22, 22-jdk
173c173
< Tags: 22-al2023-headless, 22.0.0-al2023-headless
---
> Tags: 22-al2023-headless, 22.0.0-al2023-headless, 22-headless
177c177
< Tags: 22-al2023-headful, 22.0.0-al2023-headful
---
> Tags: 22-al2023-headful, 22.0.0-al2023-headful, 22-headful
195a196
> 
```