### PR TITLE
Update Debian base from buster (10) to bookworm (12)

### DIFF
--- a/11/jdk/debian/Dockerfile
+++ b/11/jdk/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG version=11.0.25.9-1
 # In addition to installing the Amazon corretto, we also install
@@ -13,14 +13,15 @@ ARG version=11.0.25.9-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
-    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
-    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
-    && mkdir -p /usr/share/man/man1 || true \
+        curl ca-certificates fontconfig java-common \
+    && curl -fLo /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/corretto.asc] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
     && apt-get update \
     && apt-get install -y java-11-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+        curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto

--- a/17/jdk/debian/Dockerfile
+++ b/17/jdk/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG version=17.0.13.11-1
 # In addition to installing the Amazon corretto, we also install
@@ -13,14 +13,15 @@ ARG version=17.0.13.11-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
-    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
-    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
-    && mkdir -p /usr/share/man/man1 || true \
+        curl ca-certificates fontconfig java-common \
+    && curl -fLo /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/corretto.asc] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
     && apt-get update \
     && apt-get install -y java-17-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+        curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto

--- a/17/slim/debian/Dockerfile
+++ b/17/slim/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG version=17.0.13.11-1
 # In addition to installing the Amazon corretto, we also install
@@ -15,15 +15,16 @@ ARG version=17.0.13.11-1
 RUN set -ux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig \
-    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
-    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
-    && mkdir -p /usr/share/man/man1 \
+        curl ca-certificates fontconfig \
+    && curl -fLo /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/corretto.asc] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
     && apt-get update \
     && apt-get install -y java-17-amazon-corretto-jdk=1:$version binutils \
     && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-            curl gnupg software-properties-common binutils java-17-amazon-corretto-jdk=1:$version \
+            curl binutils java-17-amazon-corretto-jdk=1:$version \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /usr/lib/jvm \
     && mv /opt/corretto-slim /usr/lib/jvm/java-17-amazon-corretto \
     && jdk_tools="java keytool rmid rmiregistry javac jaotc jlink jmod jhsdb jar jarsigner javadoc javap jcmd jconsole jdb jdeps jdeprscan jimage jinfo jmap jps jrunscript jshell jstack jstat jstatd serialver" \

--- a/21/jdk/debian/Dockerfile
+++ b/21/jdk/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG version=21.0.5.11-1
 # In addition to installing the Amazon corretto, we also install
@@ -13,14 +13,15 @@ ARG version=21.0.5.11-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
-    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
-    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
-    && mkdir -p /usr/share/man/man1 || true \
+        curl ca-certificates fontconfig java-common \
+    && curl -fLo /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/corretto.asc] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
     && apt-get update \
     && apt-get install -y java-21-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+        curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-21-amazon-corretto

--- a/21/slim/debian/Dockerfile
+++ b/21/slim/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG version=21.0.5.11-1
 # In addition to installing the Amazon corretto, we also install
@@ -12,18 +12,19 @@ ARG version=21.0.5.11-1
 #
 # Slim:
 #   JLink is used (retaining all modules) to create a slimmer version of the JDK excluding man-pages, header files and debugging symbols - saving ~113MB.
-RUN set -ux \
+RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig \
-    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
-    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
-    && mkdir -p /usr/share/man/man1 \
+        curl ca-certificates fontconfig \
+    && curl -fLo /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/corretto.asc] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
     && apt-get update \
     && apt-get install -y java-21-amazon-corretto-jdk=1:$version binutils \
     && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-            curl gnupg software-properties-common binutils java-21-amazon-corretto-jdk=1:$version \
+            curl binutils java-21-amazon-corretto-jdk=1:$version \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /usr/lib/jvm \
     && mv /opt/corretto-slim /usr/lib/jvm/java-21-amazon-corretto \
     && jdk_tools="java keytool rmid rmiregistry javac jaotc jlink jmod jhsdb jar jarsigner javadoc javap jcmd jconsole jdb jdeps jdeprscan jimage jinfo jmap jps jrunscript jshell jstack jstat jstatd serialver" \

--- a/23/jdk/debian/Dockerfile
+++ b/23/jdk/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG version=23.0.1.8-1
 # In addition to installing the Amazon corretto, we also install
@@ -13,14 +13,15 @@ ARG version=23.0.1.8-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
-    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
-    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
-    && mkdir -p /usr/share/man/man1 || true \
+        curl ca-certificates fontconfig java-common \
+    && curl -fLo /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/corretto.asc] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
     && apt-get update \
     && apt-get install -y java-23-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+        curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-23-amazon-corretto

--- a/23/slim/debian/Dockerfile
+++ b/23/slim/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG version=23.0.1.8-1
 # In addition to installing the Amazon corretto, we also install
@@ -15,15 +15,16 @@ ARG version=23.0.1.8-1
 RUN set -ux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig \
-    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
-    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
-    && mkdir -p /usr/share/man/man1 \
+        curl ca-certificates fontconfig \
+    && curl -fLo /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/corretto.asc] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
     && apt-get update \
     && apt-get install -y java-23-amazon-corretto-jdk=1:$version binutils \
     && jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-            curl gnupg software-properties-common binutils java-23-amazon-corretto-jdk=1:$version \
+            curl binutils java-23-amazon-corretto-jdk=1:$version \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /usr/lib/jvm \
     && mv /opt/corretto-slim /usr/lib/jvm/java-23-amazon-corretto \
     && jdk_tools="java keytool rmid rmiregistry javac jaotc jlink jmod jhsdb jar jarsigner javadoc javap jcmd jconsole jdb jdeps jdeprscan jimage jinfo jmap jps jrunscript jshell jstack jstat jstatd serialver" \

--- a/8/jdk/debian/Dockerfile
+++ b/8/jdk/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG version=8.432.06-1
 # In addition to installing the Amazon corretto, we also install
@@ -13,14 +13,15 @@ ARG version=8.432.06-1
 RUN set -eux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        curl ca-certificates gnupg software-properties-common fontconfig java-common \
-    && curl -fL https://apt.corretto.aws/corretto.key | apt-key add - \
-    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
-    && mkdir -p /usr/share/man/man1 || true \
+        curl ca-certificates fontconfig java-common \
+    && curl -fLo /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \
+    && echo "deb [signed-by=/etc/apt/keyrings/corretto.asc] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list \
     && apt-get update \
     && apt-get install -y java-1.8.0-amazon-corretto-jdk=1:$version \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-        curl gnupg software-properties-common
+        curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LANG=C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-amazon-corretto


### PR DESCRIPTION
*Description of changes:*

I know the Debian images aren't published, but if they are here and should
serve as an example, they should probably implement best practices. Therefore,
this updates a few things:

- Updates from (EOL) Debian 10 (buster) to current stable (Debian 12/bookworm)
- Avoids using the deprecated apt-key tool
- Uses an explicit keyring file (https://wiki.debian.org/DebianRepository/UseThirdParty)
- Clean up apt caches after install (same as #191)

This also means we don't need gnupg & software-properties-common anymore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
