### PR TITLE
Add fonts (& infrastructure) to Alpine images

### DIFF
--- a/11/jdk/alpine/3.18/Dockerfile
+++ b/11/jdk/alpine/3.18/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-11=$version-r0 && \
+    apk add --no-cache amazon-corretto-11=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-11-amazon-corretto/lib/src.zip
 
 

--- a/11/jdk/alpine/3.19/Dockerfile
+++ b/11/jdk/alpine/3.19/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-11=$version-r0 && \
+    apk add --no-cache amazon-corretto-11=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-11-amazon-corretto/lib/src.zip
 
 

--- a/11/jdk/alpine/3.20/Dockerfile
+++ b/11/jdk/alpine/3.20/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-11=$version-r0 && \
+    apk add --no-cache amazon-corretto-11=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-11-amazon-corretto/lib/src.zip
 
 

--- a/17/jdk/alpine/3.18/Dockerfile
+++ b/17/jdk/alpine/3.18/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0 && \
+    apk add --no-cache amazon-corretto-17=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-17-amazon-corretto/lib/src.zip
 
 

--- a/17/jdk/alpine/3.19/Dockerfile
+++ b/17/jdk/alpine/3.19/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0 && \
+    apk add --no-cache amazon-corretto-17=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-17-amazon-corretto/lib/src.zip
 
 

--- a/17/jdk/alpine/3.20/Dockerfile
+++ b/17/jdk/alpine/3.20/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0 && \
+    apk add --no-cache amazon-corretto-17=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-17-amazon-corretto/lib/src.zip
 
 

--- a/17/slim/alpine/Dockerfile
+++ b/17/slim/alpine/Dockerfile
@@ -15,7 +15,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-17=$version-r0 binutils && \
+    apk add --no-cache amazon-corretto-17=$version-r0 binutils font-droid && \
     /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
     apk del binutils amazon-corretto-17 && \
     mkdir -p /usr/lib/jvm/ && \

--- a/21/jdk/alpine/3.18/Dockerfile
+++ b/21/jdk/alpine/3.18/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-21=$version-r0 && \
+    apk add --no-cache amazon-corretto-21=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-21-amazon-corretto/lib/src.zip
 
 

--- a/21/jdk/alpine/3.19/Dockerfile
+++ b/21/jdk/alpine/3.19/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-21=$version-r0 && \
+    apk add --no-cache amazon-corretto-21=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-21-amazon-corretto/lib/src.zip
 
 

--- a/21/jdk/alpine/3.20/Dockerfile
+++ b/21/jdk/alpine/3.20/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-21=$version-r0 && \
+    apk add --no-cache amazon-corretto-21=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-21-amazon-corretto/lib/src.zip
 
 

--- a/21/slim/alpine/Dockerfile
+++ b/21/slim/alpine/Dockerfile
@@ -15,7 +15,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-21=$version-r0 binutils && \
+    apk add --no-cache amazon-corretto-21=$version-r0 binutils font-droid && \
     /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
     apk del binutils amazon-corretto-21 && \
     mkdir -p /usr/lib/jvm/ && \

--- a/23/jdk/alpine/3.18/Dockerfile
+++ b/23/jdk/alpine/3.18/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-23=$version-r0 && \
+    apk add --no-cache amazon-corretto-23=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-23-amazon-corretto/lib/src.zip
 
 

--- a/23/jdk/alpine/3.19/Dockerfile
+++ b/23/jdk/alpine/3.19/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-23=$version-r0 && \
+    apk add --no-cache amazon-corretto-23=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-23-amazon-corretto/lib/src.zip
 
 

--- a/23/jdk/alpine/3.20/Dockerfile
+++ b/23/jdk/alpine/3.20/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-23=$version-r0 && \
+    apk add --no-cache amazon-corretto-23=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-23-amazon-corretto/lib/src.zip
 
 

--- a/23/slim/alpine/Dockerfile
+++ b/23/slim/alpine/Dockerfile
@@ -15,7 +15,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-23=$version-r0 binutils && \
+    apk add --no-cache amazon-corretto-23=$version-r0 binutils font-droid && \
     /usr/lib/jvm/default-jvm/bin/jlink --add-modules "$(java --list-modules | sed -e 's/@[0-9].*$/,/' | tr -d \\n)" --no-man-pages --no-header-files --strip-debug --output /opt/corretto-slim && \
     apk del binutils amazon-corretto-23 && \
     mkdir -p /usr/lib/jvm/ && \

--- a/8/jdk/alpine/3.18/Dockerfile
+++ b/8/jdk/alpine/3.18/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8=$version-r0 && \
+    apk add --no-cache amazon-corretto-8=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
 
 

--- a/8/jdk/alpine/3.19/Dockerfile
+++ b/8/jdk/alpine/3.19/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8=$version-r0 && \
+    apk add --no-cache amazon-corretto-8=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
 
 

--- a/8/jdk/alpine/3.20/Dockerfile
+++ b/8/jdk/alpine/3.20/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8=$version-r0 && \
+    apk add --no-cache amazon-corretto-8=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
 
 

--- a/8/jre/alpine/3.18/Dockerfile
+++ b/8/jre/alpine/3.18/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8-jre=$version-r0 && \
+    apk add --no-cache amazon-corretto-8-jre=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
 
 

--- a/8/jre/alpine/3.19/Dockerfile
+++ b/8/jre/alpine/3.19/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8-jre=$version-r0 && \
+    apk add --no-cache amazon-corretto-8-jre=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
 
 

--- a/8/jre/alpine/3.20/Dockerfile
+++ b/8/jre/alpine/3.20/Dockerfile
@@ -12,7 +12,7 @@ RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads
     SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
     echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
     echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
-    apk add --no-cache amazon-corretto-8-jre=$version-r0 && \
+    apk add --no-cache amazon-corretto-8-jre=$version-r0 font-droid && \
     rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
 
 


### PR DESCRIPTION
*Issue #, if available:* #112 & #108

*Description of changes:*

Instead of creating a new "headless" variant of the Alpine images, this just adds [font-droid](https://pkgs.alpinelinux.org/package/v3.20/main/x86_64/font-droid) to all the Alpine images. This pulls in fontconfig & freetype, which allows Java/AWT to render fonts (see #108 for details). This only adds about 6MB to each image, which I find reasonable.

I selected Droid, since it is a bit smaller then other fonts, under a simple license (Apache 2.0) and has a reasonable selection of alternatives (Serif, Sans-Serif, Mono)

<details>
<summary>Size comparison</summary>
For reference, here is a list of images with different fonts included:

```
localhost/corretto-8-jre-dejavu      latest        8a58b4581222  17 minutes ago  133 MB
localhost/corretto-8-jre-freefont    latest        85d045e180db  17 minutes ago  129 MB
localhost/corretto-8-jre-noto        latest        d09ff1c4dc7b  17 minutes ago  135 MB
localhost/corretto-8-jre-droid       latest        bd1d14675e33  17 minutes ago  123 MB
localhost/corretto-8-jre-opensans    latest        f0a3f149c4e7  17 minutes ago  125 MB
localhost/corretto-8-jre-liberation  latest        f8aa030f28f4  17 minutes ago  126 MB
docker.io/library/amazoncorretto     8-alpine-jre  e79af4bd4f9e  13 days ago     116 MB
``` 
</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
