### PR TITLE
Fix tag-generator.py (3.21 to 3.20) based on 500f60a

### DIFF
--- a/bin/tag-generator.py
+++ b/bin/tag-generator.py
@@ -1,6 +1,6 @@
 import json
 
-DEFAULT_ALPINE_VERSION = '3.21'
+DEFAULT_ALPINE_VERSION = '3.20'
 ALPINE_VERSIONS = ['3.18', '3.19', '3.20']
 
 def generate_tags(key, version):


### PR DESCRIPTION
Added 3.21 instead of 3.20.
3.21 Q1