### PR TITLE
Update Alpine to 3.21

### DIFF
--- a/.github/workflows/verify-images.yml
+++ b/.github/workflows/verify-images.yml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ 8, 11, 17, 21, 23 ]
-        os_version: ["3.18", "3.19", "3.20"]
+        os_version: ["3.18", "3.19", "3.20", "3.21"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/11/jdk/alpine/3.21/Dockerfile
+++ b/11/jdk/alpine/3.21/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:3.21
+
+ARG version=11.0.26.4.1
+
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
+# The Corretto team will update this file but you may see a few days' delay.
+RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
+    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
+    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
+    apk add --no-cache amazon-corretto-11=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-11-amazon-corretto/lib/src.zip
+
+
+ENV LANG=C.UTF-8
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/17/jdk/alpine/3.21/Dockerfile
+++ b/17/jdk/alpine/3.21/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:3.21
+
+ARG version=17.0.14.7.1
+
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
+# The Corretto team will update this file but you may see a few days' delay.
+RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
+    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
+    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
+    apk add --no-cache amazon-corretto-17=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-17-amazon-corretto/lib/src.zip
+
+
+ENV LANG=C.UTF-8
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/21/jdk/alpine/3.21/Dockerfile
+++ b/21/jdk/alpine/3.21/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:3.21
+
+ARG version=21.0.6.7.1
+
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
+# The Corretto team will update this file but you may see a few days' delay.
+RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
+    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
+    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
+    apk add --no-cache amazon-corretto-21=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-21-amazon-corretto/lib/src.zip
+
+
+ENV LANG=C.UTF-8
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/23/jdk/alpine/3.21/Dockerfile
+++ b/23/jdk/alpine/3.21/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:3.21
+
+ARG version=23.0.2.7.1
+
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
+# The Corretto team will update this file but you may see a few days' delay.
+RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
+    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
+    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
+    apk add --no-cache amazon-corretto-23=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-23-amazon-corretto/lib/src.zip
+
+
+ENV LANG=C.UTF-8
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/8/jdk/alpine/3.21/Dockerfile
+++ b/8/jdk/alpine/3.21/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:3.21
+
+ARG version=8.442.06.1
+
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
+# The Corretto team will update this file but you may see a few days' delay.
+RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
+    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
+    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
+    apk add --no-cache amazon-corretto-8=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
+ENV LANG=C.UTF-8
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm
+ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin

--- a/8/jre/alpine/3.21/Dockerfile
+++ b/8/jre/alpine/3.21/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:3.21
+
+ARG version=8.442.06.1
+
+# Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
+# The Corretto team will update this file but you may see a few days' delay.
+RUN wget -O /THIRD-PARTY-LICENSES-20200824.tar.gz https://corretto.aws/downloads/resources/licenses/alpine/THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    echo "82f3e50e71b2aee21321b2b33de372feed5befad6ef2196ddec92311bc09becb  /THIRD-PARTY-LICENSES-20200824.tar.gz" | sha256sum -c - && \
+    tar x -ovzf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    rm -rf THIRD-PARTY-LICENSES-20200824.tar.gz && \
+    wget -O /etc/apk/keys/amazoncorretto.rsa.pub https://apk.corretto.aws/amazoncorretto.rsa.pub && \
+    SHA_SUM="6cfdf08be09f32ca298e2d5bd4a359ee2b275765c09b56d514624bf831eafb91" && \
+    echo "${SHA_SUM}  /etc/apk/keys/amazoncorretto.rsa.pub" | sha256sum -c - && \
+    echo "https://apk.corretto.aws" >> /etc/apk/repositories && \
+    apk add --no-cache amazon-corretto-8-jre=$version-r0 && \
+    rm -rf /usr/lib/jvm/java-8-amazon-corretto/lib/src.zip
+
+
+ENV LANG=C.UTF-8
+
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre

--- a/bin/apply-template.py
+++ b/bin/apply-template.py
@@ -13,7 +13,7 @@ def process_template_files(major_version, version, platform):
     input_parameter['MAJOR_VERSION'] = major_version
     if platform == 'alpine':
         # Update .github/workflows/verify-images.yml as well when alpine versions changes
-        os_versions = ['3.18', '3.19', '3.20']
+        os_versions = ['3.18', '3.19', '3.20', '3.21']
     try:
         shutil.rmtree(f"{major_version}/jdk/{platform}")
         shutil.rmtree(f"{major_version}/jre/{platform}")

--- a/bin/tag-generator.py
+++ b/bin/tag-generator.py
@@ -1,7 +1,7 @@
 import json
 
-DEFAULT_ALPINE_VERSION = '3.20'
-ALPINE_VERSIONS = ['3.18', '3.19', '3.20']
+DEFAULT_ALPINE_VERSION = '3.21'
+ALPINE_VERSIONS = ['3.18', '3.19', '3.20', '3.21']
 
 def generate_tags(key, version):
     update = version.split('.')[1] if (key == '8') else version.split('.')[2]


### PR DESCRIPTION
Updating Alpine to 3.21 as Latest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
