### PR TITLE
Add tag for latest update version pointing to al2023 jdk.

### DIFF
--- a/bin/tag-generator.py
+++ b/bin/tag-generator.py
@@ -39,6 +39,7 @@ def generate_tags(key, version):
     if int(key) >= 22:
         al2023_tags.append(f"{key}")
         al2023_tags.append(f"{key}-jdk")
+        al2023_tags.append(f"{amazon_expanded_version}")
         al2023_headless_tags.append(f"{key}-headless")
         al2023_headful_tags.append(f"{key}-headful")
 


### PR DESCRIPTION
Addresses https://github.com/corretto/corretto-docker/issues/257

25.0.1 will point to the same image as 25, which will be the full JDK package.
```
Tags: 25-al2023, 25.0.1-al2023, 25-al2023-jdk, 25, 25-jdk, 25.0.1
Architectures: amd64, arm64v8
Directory: 25/jdk/al2023
```


```
$ python3 ./bin/tag-generator.py 
Tags: 8, 8u472, 8u472-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u472-al2-generic, 8-al2-generic-jdk, latest
Architectures: amd64, arm64v8
Directory: 8/jdk/al2-generic

Tags: 8-al2023, 8u472-al2023, 8-al2023-jdk
Architectures: amd64, arm64v8
Directory: 8/jdk/al2023

Tags: 8-al2023-jre, 8u472-al2023-jre
Architectures: amd64, arm64v8
Directory: 8/jdk/al2023

Tags: 8-al2-native-jre, 8u472-al2-native-jre
Architectures: amd64, arm64v8
Directory: 8/jre/al2

Tags: 8-al2-native-jdk, 8u472-al2-native-jdk
Architectures: amd64, arm64v8
Directory: 8/jdk/al2

Tags: 8-alpine3.19, 8u472-alpine3.19, 8-alpine3.19-full, 8-alpine3.19-jdk
Architectures: amd64, arm64v8
Directory: 8/jdk/alpine/3.19

Tags: 8-alpine3.19-jre, 8u472-alpine3.19-jre
Architectures: amd64, arm64v8
Directory: 8/jre/alpine/3.19

Tags: 8-alpine3.20, 8u472-alpine3.20, 8-alpine3.20-full, 8-alpine3.20-jdk
Architectures: amd64, arm64v8
Directory: 8/jdk/alpine/3.20

Tags: 8-alpine3.20-jre, 8u472-alpine3.20-jre
Architectures: amd64, arm64v8
Directory: 8/jre/alpine/3.20

Tags: 8-alpine3.21, 8u472-alpine3.21, 8-alpine3.21-full, 8-alpine3.21-jdk
Architectures: amd64, arm64v8
Directory: 8/jdk/alpine/3.21

Tags: 8-alpine3.21-jre, 8u472-alpine3.21-jre
Architectures: amd64, arm64v8
Directory: 8/jre/alpine/3.21

Tags: 8-alpine3.22, 8u472-alpine3.22, 8-alpine3.22-full, 8-alpine3.22-jdk, 8-alpine, 8u472-alpine, 8-alpine-full, 8-alpine-jdk
Architectures: amd64, arm64v8
Directory: 8/jdk/alpine/3.22

Tags: 8-alpine3.22-jre, 8u472-alpine3.22-jre, 8-alpine-jre, 8u472-alpine-jre
Architectures: amd64, arm64v8
Directory: 8/jre/alpine/3.22

Tags: 11, 11.0.29, 11.0.29-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.29-al2-generic, 11-al2-generic-jdk
Architectures: amd64, arm64v8
Directory: 11/jdk/al2-generic

Tags: 11-al2023, 11.0.29-al2023, 11-al2023-jdk
Architectures: amd64, arm64v8
Directory: 11/jdk/al2023

Tags: 11-al2023-headless, 11.0.29-al2023-headless
Architectures: amd64, arm64v8
Directory: 11/headless/al2023

Tags: 11-al2023-headful, 11.0.29-al2023-headful
Architectures: amd64, arm64v8
Directory: 11/headful/al2023

Tags: 11-al2-native-headless, 11.0.29-al2-native-headless
Architectures: amd64, arm64v8
Directory: 11/headless/al2

Tags: 11-al2-native-jdk, 11.0.29-al2-native-jdk
Architectures: amd64, arm64v8
Directory: 11/jdk/al2

Tags: 11-alpine3.19, 11.0.29-alpine3.19, 11-alpine3.19-full, 11-alpine3.19-jdk
Architectures: amd64, arm64v8
Directory: 11/jdk/alpine/3.19

Tags: 11-alpine3.20, 11.0.29-alpine3.20, 11-alpine3.20-full, 11-alpine3.20-jdk
Architectures: amd64, arm64v8
Directory: 11/jdk/alpine/3.20

Tags: 11-alpine3.21, 11.0.29-alpine3.21, 11-alpine3.21-full, 11-alpine3.21-jdk
Architectures: amd64, arm64v8
Directory: 11/jdk/alpine/3.21

Tags: 11-alpine3.22, 11.0.29-alpine3.22, 11-alpine3.22-full, 11-alpine3.22-jdk, 11-alpine, 11.0.29-alpine, 11-alpine-full, 11-alpine-jdk
Architectures: amd64, arm64v8
Directory: 11/jdk/alpine/3.22

Tags: 17, 17.0.17, 17.0.17-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.17-al2-generic, 17-al2-generic-jdk
Architectures: amd64, arm64v8
Directory: 17/jdk/al2-generic

Tags: 17-al2023, 17.0.17-al2023, 17-al2023-jdk
Architectures: amd64, arm64v8
Directory: 17/jdk/al2023

Tags: 17-al2023-headless, 17.0.17-al2023-headless
Architectures: amd64, arm64v8
Directory: 17/headless/al2023

Tags: 17-al2023-headful, 17.0.17-al2023-headful
Architectures: amd64, arm64v8
Directory: 17/headful/al2023

Tags: 17-al2-native-headless, 17.0.17-al2-native-headless
Architectures: amd64, arm64v8
Directory: 17/headless/al2

Tags: 17-al2-native-headful, 17.0.17-al2-native-headful
Architectures: amd64, arm64v8
Directory: 17/headful/al2

Tags: 17-al2-native-jdk, 17.0.17-al2-native-jdk
Architectures: amd64, arm64v8
Directory: 17/jdk/al2

Tags: 17-alpine3.19, 17.0.17-alpine3.19, 17-alpine3.19-full, 17-alpine3.19-jdk
Architectures: amd64, arm64v8
Directory: 17/jdk/alpine/3.19

Tags: 17-alpine3.20, 17.0.17-alpine3.20, 17-alpine3.20-full, 17-alpine3.20-jdk
Architectures: amd64, arm64v8
Directory: 17/jdk/alpine/3.20

Tags: 17-alpine3.21, 17.0.17-alpine3.21, 17-alpine3.21-full, 17-alpine3.21-jdk
Architectures: amd64, arm64v8
Directory: 17/jdk/alpine/3.21

Tags: 17-alpine3.22, 17.0.17-alpine3.22, 17-alpine3.22-full, 17-alpine3.22-jdk, 17-alpine, 17.0.17-alpine, 17-alpine-full, 17-alpine-jdk
Architectures: amd64, arm64v8
Directory: 17/jdk/alpine/3.22

Tags: 21, 21.0.9, 21.0.9-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.9-al2-generic, 21-al2-generic-jdk
Architectures: amd64, arm64v8
Directory: 21/jdk/al2-generic

Tags: 21-al2023, 21.0.9-al2023, 21-al2023-jdk
Architectures: amd64, arm64v8
Directory: 21/jdk/al2023

Tags: 21-al2023-headless, 21.0.9-al2023-headless
Architectures: amd64, arm64v8
Directory: 21/headless/al2023

Tags: 21-al2023-headful, 21.0.9-al2023-headful
Architectures: amd64, arm64v8
Directory: 21/headful/al2023

Tags: 21-alpine3.19, 21.0.9-alpine3.19, 21-alpine3.19-full, 21-alpine3.19-jdk
Architectures: amd64, arm64v8
Directory: 21/jdk/alpine/3.19

Tags: 21-alpine3.20, 21.0.9-alpine3.20, 21-alpine3.20-full, 21-alpine3.20-jdk
Architectures: amd64, arm64v8
Directory: 21/jdk/alpine/3.20

Tags: 21-alpine3.21, 21.0.9-alpine3.21, 21-alpine3.21-full, 21-alpine3.21-jdk
Architectures: amd64, arm64v8
Directory: 21/jdk/alpine/3.21

Tags: 21-alpine3.22, 21.0.9-alpine3.22, 21-alpine3.22-full, 21-alpine3.22-jdk, 21-alpine, 21.0.9-alpine, 21-alpine-full, 21-alpine-jdk
Architectures: amd64, arm64v8
Directory: 21/jdk/alpine/3.22

Tags: 25-al2023, 25.0.1-al2023, 25-al2023-jdk, 25, 25-jdk, 25.0.1
Architectures: amd64, arm64v8
Directory: 25/jdk/al2023

Tags: 25-al2023-headless, 25.0.1-al2023-headless, 25-headless
Architectures: amd64, arm64v8
Directory: 25/headless/al2023

Tags: 25-al2023-headful, 25.0.1-al2023-headful, 25-headful
Architectures: amd64, arm64v8
Directory: 25/headful/al2023

Tags: 25-alpine3.19, 25.0.1-alpine3.19, 25-alpine3.19-full, 25-alpine3.19-jdk
Architectures: amd64, arm64v8
Directory: 25/jdk/alpine/3.19

Tags: 25-alpine3.20, 25.0.1-alpine3.20, 25-alpine3.20-full, 25-alpine3.20-jdk
Architectures: amd64, arm64v8
Directory: 25/jdk/alpine/3.20

Tags: 25-alpine3.21, 25.0.1-alpine3.21, 25-alpine3.21-full, 25-alpine3.21-jdk
Architectures: amd64, arm64v8
Directory: 25/jdk/alpine/3.21

Tags: 25-alpine3.22, 25.0.1-alpine3.22, 25-alpine3.22-full, 25-alpine3.22-jdk, 25-alpine, 25.0.1-alpine, 25-alpine-full, 25-alpine-jdk
Architectures: amd64, arm64v8
Directory: 25/jdk/alpine/3.22
```