### PR TITLE
Updating version for alpine/debian 26 images

### DIFF
--- a/26/slim/alpine/Dockerfile
+++ b/26/slim/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.23
 
-ARG version=26.0.0.35.1
+ARG version=26.0.0.35.2
 
 # Please note that the THIRD-PARTY-LICENSE could be out of date if the base image has been updated recently.
 # The Corretto team will update this file but you may see a few days' delay.

--- a/26/slim/debian/Dockerfile
+++ b/26/slim/debian/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ARG version=26.0.0.35-1
+ARG version=26.0.0.35-2
 # In addition to installing the Amazon corretto, we also install
 # fontconfig. The folks who manage the docker hub's
 # official image library have found that font management


### PR DESCRIPTION
Following up to previous PR: https://github.com/corretto/corretto-docker/pull/272, updating version numbers