### PR TITLE
Replace uname -m with rpm --query for userspace arch detection

### DIFF
--- a/11/headful/al2023/Dockerfile
+++ b/11/headful/al2023/Dockerfile
@@ -2,18 +2,19 @@ FROM amazonlinux:2023
 
 ARG version=11.0.30.7-1
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2023.$(uname -m).rpm" "java-11-amazon-corretto-$version.amzn2023.$(uname -m).rpm") \
+    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2023.${ARCH}.rpm" "java-11-amazon-corretto-$version.amzn2023.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-11-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-11-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/11/headless/al2/Dockerfile
+++ b/11/headless/al2/Dockerfile
@@ -3,12 +3,13 @@ FROM amazonlinux:2
 ARG version=11.0.30.7-1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && export resouce_version=$(echo $version | tr '-' '.') \
     && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 \
     && echo "localpkg_gpgcheck=1" >> /etc/yum.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2.$(uname -m).rpm") \
+    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1 \
@@ -16,7 +17,7 @@ RUN set -eux \
     done \
     && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && (find /usr/lib/jvm/java-11-amazon-corretto.$(uname -m) -name src.zip -delete || true) \
+    && (find /usr/lib/jvm/java-11-amazon-corretto.${ARCH} -name src.zip -delete || true) \
     && rm -rf ${CORRETO_TEMP} \
     && yum clean all \
     && rm -rf /var/cache/yum \

--- a/11/headless/al2023/Dockerfile
+++ b/11/headless/al2023/Dockerfile
@@ -2,18 +2,19 @@ FROM amazonlinux:2023
 
 ARG version=11.0.30.7-1
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2023.$(uname -m).rpm") \
+    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2023.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-11-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-11-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/11/jdk/al2/Dockerfile
+++ b/11/jdk/al2/Dockerfile
@@ -3,12 +3,13 @@ FROM amazonlinux:2
 ARG version=11.0.30.7-1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && export resouce_version=$(echo $version | tr '-' '.') \
     && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 \
     && echo "localpkg_gpgcheck=1" >> /etc/yum.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2.$(uname -m).rpm" "java-11-amazon-corretto-$version.amzn2.$(uname -m).rpm") \
+    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2.${ARCH}.rpm" "java-11-amazon-corretto-$version.amzn2.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1 \
@@ -16,7 +17,7 @@ RUN set -eux \
     done \
     && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && (find /usr/lib/jvm/java-11-amazon-corretto.$(uname -m) -name src.zip -delete || true) \
+    && (find /usr/lib/jvm/java-11-amazon-corretto.${ARCH} -name src.zip -delete || true) \
     && rm -rf ${CORRETO_TEMP} \
     && yum clean all \
     && rm -rf /var/cache/yum \

--- a/11/jdk/al2023/Dockerfile
+++ b/11/jdk/al2023/Dockerfile
@@ -3,18 +3,19 @@ FROM amazonlinux:2023
 ARG version=11.0.30.7-1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2023.$(uname -m).rpm" "java-11-amazon-corretto-$version.amzn2023.$(uname -m).rpm" "java-11-amazon-corretto-devel-$version.amzn2023.$(uname -m).rpm" "java-11-amazon-corretto-jmods-$version.amzn2023.$(uname -m).rpm") \
+    && RPM_LIST=("java-11-amazon-corretto-headless-$version.amzn2023.${ARCH}.rpm" "java-11-amazon-corretto-$version.amzn2023.${ARCH}.rpm" "java-11-amazon-corretto-devel-$version.amzn2023.${ARCH}.rpm" "java-11-amazon-corretto-jmods-$version.amzn2023.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-11-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-11-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/17/headful/al2/Dockerfile
+++ b/17/headful/al2/Dockerfile
@@ -3,12 +3,13 @@ FROM amazonlinux:2
 ARG version=17.0.18.9-1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && export resouce_version=$(echo $version | tr '-' '.') \
     && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 \
     && echo "localpkg_gpgcheck=1" >> /etc/yum.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-$version.amzn2.1.$(uname -m).rpm") \
+    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2.1.${ARCH}.rpm" "java-17-amazon-corretto-$version.amzn2.1.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1 \
@@ -16,7 +17,7 @@ RUN set -eux \
     done \
     && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && (find /usr/lib/jvm/java-17-amazon-corretto.$(uname -m) -name src.zip -delete || true) \
+    && (find /usr/lib/jvm/java-17-amazon-corretto.${ARCH} -name src.zip -delete || true) \
     && rm -rf ${CORRETO_TEMP} \
     && yum clean all \
     && rm -rf /var/cache/yum \

--- a/17/headful/al2023/Dockerfile
+++ b/17/headful/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=17.0.18.9-1
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-17-amazon-corretto-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-17-amazon-corretto-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-17-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-17-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/17/headless/al2/Dockerfile
+++ b/17/headless/al2/Dockerfile
@@ -3,12 +3,13 @@ FROM amazonlinux:2
 ARG version=17.0.18.9-1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && export resouce_version=$(echo $version | tr '-' '.') \
     && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 \
     && echo "localpkg_gpgcheck=1" >> /etc/yum.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2.1.$(uname -m).rpm") \
+    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2.1.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1 \
@@ -16,7 +17,7 @@ RUN set -eux \
     done \
     && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && (find /usr/lib/jvm/java-17-amazon-corretto.$(uname -m) -name src.zip -delete || true) \
+    && (find /usr/lib/jvm/java-17-amazon-corretto.${ARCH} -name src.zip -delete || true) \
     && rm -rf ${CORRETO_TEMP} \
     && yum clean all \
     && rm -rf /var/cache/yum \

--- a/17/headless/al2023/Dockerfile
+++ b/17/headless/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=17.0.18.9-1
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-17-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-17-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/17/jdk/al2/Dockerfile
+++ b/17/jdk/al2/Dockerfile
@@ -3,12 +3,13 @@ FROM amazonlinux:2
 ARG version=17.0.18.9-1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && export resouce_version=$(echo $version | tr '-' '.') \
     && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 \
     && echo "localpkg_gpgcheck=1" >> /etc/yum.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-devel-$version.amzn2.1.$(uname -m).rpm" "java-17-amazon-corretto-jmods-$version.amzn2.1.$(uname -m).rpm") \
+    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2.1.${ARCH}.rpm" "java-17-amazon-corretto-$version.amzn2.1.${ARCH}.rpm" "java-17-amazon-corretto-devel-$version.amzn2.1.${ARCH}.rpm" "java-17-amazon-corretto-jmods-$version.amzn2.1.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1 \
@@ -18,7 +19,7 @@ RUN set -eux \
       done \
     && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && (find /usr/lib/jvm/java-17-amazon-corretto.$(uname -m) -name src.zip -delete || true) \
+    && (find /usr/lib/jvm/java-17-amazon-corretto.${ARCH} -name src.zip -delete || true) \
     && rm -rf ${CORRETO_TEMP} \
     && yum clean all \
     && rm -rf /var/cache/yum \

--- a/17/jdk/al2023/Dockerfile
+++ b/17/jdk/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=17.0.18.9-1
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-17-amazon-corretto-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-17-amazon-corretto-devel-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-17-amazon-corretto-jmods-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-17-amazon-corretto-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-17-amazon-corretto-devel-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-17-amazon-corretto-jmods-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-17-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-17-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/21/headful/al2023/Dockerfile
+++ b/21/headful/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=21.0.10.7-1
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-21-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-21-amazon-corretto-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-21-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-21-amazon-corretto-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-21-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-21-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/21/headless/al2023/Dockerfile
+++ b/21/headless/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=21.0.10.7-1
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-21-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-21-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-21-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-21-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/21/jdk/al2023/Dockerfile
+++ b/21/jdk/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=21.0.10.7-1
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-21-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-21-amazon-corretto-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-21-amazon-corretto-devel-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-21-amazon-corretto-jmods-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-21-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-21-amazon-corretto-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-21-amazon-corretto-devel-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-21-amazon-corretto-jmods-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-21-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-21-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/25/headful/al2023/Dockerfile
+++ b/25/headful/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=25.0.2.10-1
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-25-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-25-amazon-corretto-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-25-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-25-amazon-corretto-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-25-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-25-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/25/headless/al2023/Dockerfile
+++ b/25/headless/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=25.0.2.10-1
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-25-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-25-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-25-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-25-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/25/jdk/al2023/Dockerfile
+++ b/25/jdk/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=25.0.2.10-1
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-25-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-25-amazon-corretto-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-25-amazon-corretto-devel-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-25-amazon-corretto-jmods-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-25-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-25-amazon-corretto-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-25-amazon-corretto-devel-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-25-amazon-corretto-jmods-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-25-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-25-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/26/headful/al2023/Dockerfile
+++ b/26/headful/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=26.0.0.35-2
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-26-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-26-amazon-corretto-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-26-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-26-amazon-corretto-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-26-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-26-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/26/headless/al2023/Dockerfile
+++ b/26/headless/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=26.0.0.35-2
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-26-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-26-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-26-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-26-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/26/jdk/al2023/Dockerfile
+++ b/26/jdk/al2023/Dockerfile
@@ -4,18 +4,19 @@ ARG version=26.0.0.35-2
 ARG package_version=1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-26-amazon-corretto-headless-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-26-amazon-corretto-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-26-amazon-corretto-devel-$version.amzn2023.${package_version}.$(uname -m).rpm" "java-26-amazon-corretto-jmods-$version.amzn2023.${package_version}.$(uname -m).rpm") \
+    && RPM_LIST=("java-26-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-26-amazon-corretto-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-26-amazon-corretto-devel-$version.amzn2023.${package_version}.${ARCH}.rpm" "java-26-amazon-corretto-jmods-$version.amzn2023.${package_version}.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-26-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-26-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf

--- a/8/jdk/al2/Dockerfile
+++ b/8/jdk/al2/Dockerfile
@@ -4,12 +4,13 @@ ARG version=1.8.0_482.b08-1
 
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && export resouce_version=$(echo $version | tr '-' '.' | tr '_' '.'| tr -d "b" | awk -F. '{print $2"."$4"."$5"."$6}') \
     && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 \
     && echo "localpkg_gpgcheck=1" >> /etc/yum.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-1.8.0-amazon-corretto-$version.amzn2.$(uname -m).rpm" "java-1.8.0-amazon-corretto-devel-$version.amzn2.$(uname -m).rpm") \
+    && RPM_LIST=("java-1.8.0-amazon-corretto-$version.amzn2.${ARCH}.rpm" "java-1.8.0-amazon-corretto-devel-$version.amzn2.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1 \
@@ -17,7 +18,7 @@ RUN set -eux \
     done \
     && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && (find /usr/lib/jvm/java-1.8.0-amazon-corretto.$(uname -m) -name "*src.zip" -delete || true) \
+    && (find /usr/lib/jvm/java-1.8.0-amazon-corretto.${ARCH} -name "*src.zip" -delete || true) \
     && rm -rf ${CORRETO_TEMP} \
     && yum clean all \
     && rm -rf /var/cache/yum \

--- a/8/jdk/al2023/Dockerfile
+++ b/8/jdk/al2023/Dockerfile
@@ -4,19 +4,20 @@ ARG version=1.8.0_482.b08-1
 
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && export resouce_version=$(echo $version | tr '-' '.' | tr '_' '.'| tr -d "b" | awk -F. '{print $2"."$4"."$5"."$6}') \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-1.8.0-amazon-corretto-$version.amzn2023.$(uname -m).rpm" "java-1.8.0-amazon-corretto-devel-$version.amzn2023.$(uname -m).rpm") \
+    && RPM_LIST=("java-1.8.0-amazon-corretto-$version.amzn2023.${ARCH}.rpm" "java-1.8.0-amazon-corretto-devel-$version.amzn2023.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-1.8.0-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-1.8.0-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && rm -rf /var/cache/yum \

--- a/8/jre/al2/Dockerfile
+++ b/8/jre/al2/Dockerfile
@@ -4,12 +4,13 @@ ARG version=1.8.0_482.b08-1
 
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && export resouce_version=$(echo $version | tr '-' '.' | tr '_' '.'| tr -d "b" | awk -F. '{print $2"."$4"."$5"."$6}') \
     && rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 \
     && echo "localpkg_gpgcheck=1" >> /etc/yum.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-1.8.0-amazon-corretto-$version.amzn2.$(uname -m).rpm") \
+    && RPM_LIST=("java-1.8.0-amazon-corretto-$version.amzn2.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
     && echo $(rpm -K "${CORRETO_TEMP}/${rpm}") \
@@ -18,7 +19,7 @@ RUN set -eux \
     && yum install -y $(yum deplist ${CORRETO_TEMP}/*.rpm |grep provider | grep -v log4j-cve | tr -s ' ' |cut -d ' ' -f 3 ) \
     && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
     && popd \
-    && rm -rf /usr/lib/jvm/java-1.8.0-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-1.8.0-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && yum clean all \
     && rm -rf /var/cache/yum \

--- a/8/jre/al2023/Dockerfile
+++ b/8/jre/al2023/Dockerfile
@@ -3,20 +3,21 @@ FROM amazonlinux:2023
 ARG version=1.8.0_482.b08-1
 
 RUN set -eux \
+    && ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" \
     && export resouce_version=$(echo $version | tr '-' '.' | tr '_' '.'| tr -d "b" | awk -F. '{print $2"."$4"."$5"."$6}') \
     && rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 \
     && echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf \
     && CORRETO_TEMP=$(mktemp -d) \
     && pushd ${CORRETO_TEMP} \
-    && RPM_LIST=("java-1.8.0-amazon-corretto-$version.amzn2023.$(uname -m).rpm") \
+    && RPM_LIST=("java-1.8.0-amazon-corretto-$version.amzn2023.${ARCH}.rpm") \
     && for rpm in ${RPM_LIST[@]}; do \
     curl --fail -O https://corretto.aws/downloads/resources/${resouce_version}/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
     && dnf install -y ${CORRETO_TEMP}/*.rpm \
-    && alternatives --install /usr/lib/jvm/java-1.8.0-amazon-corretto java-1.8.0-amazon-corretto /usr/lib/jvm/java-1.8.0-amazon-corretto.$(uname -m) 100 \
+    && alternatives --install /usr/lib/jvm/java-1.8.0-amazon-corretto java-1.8.0-amazon-corretto /usr/lib/jvm/java-1.8.0-amazon-corretto.${ARCH} 100 \
     && popd \
-    && rm -rf /usr/lib/jvm/java-1.8.0-amazon-corretto.$(uname -m)/lib/src.zip \
+    && rm -rf /usr/lib/jvm/java-1.8.0-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \
     && dnf clean all \
     && sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf


### PR DESCRIPTION
## Summary

Replace `$(uname -m)` with `rpm --query --queryformat='%{ARCH}' rpm` in all AL2 and AL2023 Dockerfiles.

## Motivation

Addresses feedback from @tianon on [PR #21053](https://github.com/docker-library/official-images/pull/21053#issuecomment-4078482994):

1. **`uname -m` reports kernel architecture**, which doesn't necessarily match the userspace architecture. Using `rpm --query` queries the actual userspace architecture, which is more correct for RPM-based images.

2. **Capture architecture in a variable before use** — inline `$(uname -m)` subshells can swallow errors. Capturing `ARCH` early in the `&&` chain ensures proper error propagation under `set -eux`.

## Changes

- Added `ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)"` early in the `RUN` command chain (right after `set -eux`)
- Replaced all `$(uname -m)` occurrences with `${ARCH}`
- **24 Dockerfiles modified** across Corretto 8, 11, 17, 21, 25, 26 (all AL2 and AL2023 variants)

## Not Modified

- Alpine Dockerfiles (use `apk add`, no `uname -m`)
- Debian Dockerfiles (use `apt-get`, no `uname -m`)
- al2-generic Dockerfiles (use `yum install` from repo, no direct RPM downloads)
- slim Dockerfiles (use package managers)

## Testing

- Built and verified `java -version` on AL2 (11/jdk/al2) and AL2023 (17/jdk/al2023, 8/jre/al2023) images
- All container-structure-tests pass
- Confirmed zero remaining `uname -m` in any AL2/AL2023 Dockerfile