### PR TITLE
Revert "Using jre definition for 8 jre image"

### DIFF
--- a/bin/tag-generator.py
+++ b/bin/tag-generator.py
@@ -49,7 +49,7 @@ def generate_tags(key, version):
     if key == '8':
         print("Tags: " + ", ".join(al2023_8_tags))
         print("Architectures: amd64, arm64v8")
-        print(f"Directory: {key}/jre/al2023\n")
+        print(f"Directory: {key}/jdk/al2023\n")
     else:
         print("Tags: " + ", ".join(al2023_headless_tags))
         print("Architectures: amd64, arm64v8")


### PR DESCRIPTION
This reverts commit 7075fecda59b24401d281af56b8960f424aefed4.

This commit was made to address [Corretto 8 AL2023 JDK and JRE are build from the same Dockerfile #265](https://github.com/corretto/corretto-docker/issues/265), which we [announced](https://github.com/corretto/corretto-docker/issues/276) to be integrated in the Q3 release to give time for anyone relying on JDK functionality to switch to the correct image.

However, the main branch tags must be updated now for a Corretto 8 security release, and should not include this fix yet. Plan is to reintroduce this commit for the Q3 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
