### PR TITLE
Reapply "Using jre definition for 8 jre image"

### DIFF
--- a/bin/tag-generator.py
+++ b/bin/tag-generator.py
@@ -49,7 +49,7 @@ def generate_tags(key, version):
     if key == '8':
         print("Tags: " + ", ".join(al2023_8_tags))
         print("Architectures: amd64, arm64v8")
-        print(f"Directory: {key}/jdk/al2023\n")
+        print(f"Directory: {key}/jre/al2023\n")
     else:
         print("Tags: " + ", ".join(al2023_headless_tags))
         print("Architectures: amd64, arm64v8")


### PR DESCRIPTION
This reverts commit 507853cc5f7441f7f37f4c0999f790e2f322d670.

*Issue #, if available: https://github.com/corretto/corretto-docker/issues/276

*Description of changes: Reapplying the fix to use correct Dockerfile for `8-al2023-jre`, to be updated alongside July Q3 release as announced prior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
