### PR TITLE
Install fontconfig in Corretto 8 native AL2 images

### DIFF
--- a/.github/workflows/verify-images.yml
+++ b/.github/workflows/verify-images.yml
@@ -80,6 +80,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Test Corretto ${{ matrix.version }} ${{ matrix.package }} package on ${{ matrix.platform }}
         run: ./bin/test-image.sh "${{ matrix.version }}/${{ matrix.package }}/${{ matrix.platform }}/Dockerfile" ${{ matrix.version }} ${{ matrix.package }}
+      - name: Test Corretto 8 Swing font support on AL2
+        if: ${{ matrix.platform == 'al2' }}
+        run: build/tool/container-structure-test-linux-amd64 test --image corretto-docker --config test/test-image-corretto8-font.yaml
 
   verify-corretto-11-plus-on-al2023:
     name: Verify Corretto 11+ Images on AL2023

--- a/8/jdk/al2/Dockerfile
+++ b/8/jdk/al2/Dockerfile
@@ -16,6 +16,7 @@ RUN set -eux \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1 \
     && yum install -y $(yum deplist "${CORRETO_TEMP}/${rpm}" |grep provider | grep -v log4j-cve | tr -s ' ' |cut -d ' ' -f 3 ); \
     done \
+    && yum install -y fontconfig \
     && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
     && popd \
     && (find /usr/lib/jvm/java-1.8.0-amazon-corretto.${ARCH} -name "*src.zip" -delete || true) \

--- a/8/jre/al2/Dockerfile
+++ b/8/jre/al2/Dockerfile
@@ -17,6 +17,7 @@ RUN set -eux \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: rsa sha1 (md5) pgp md5 OK" || exit 1; \
     done \
     && yum install -y $(yum deplist ${CORRETO_TEMP}/*.rpm |grep provider | grep -v log4j-cve | tr -s ' ' |cut -d ' ' -f 3 ) \
+    && yum install -y fontconfig \
     && rpm -i --nodeps ${CORRETO_TEMP}/*.rpm \
     && popd \
     && rm -rf /usr/lib/jvm/java-1.8.0-amazon-corretto.${ARCH}/lib/src.zip \

--- a/test/test-image-corretto8-font.yaml
+++ b/test/test-image-corretto8-font.yaml
@@ -1,0 +1,9 @@
+schemaVersion: "2.0.0"
+
+commandTests:
+  - name: "Swing UIManager can initialize fonts."
+    command: "/bin/sh"
+    args:
+      - "-c"
+      - >-
+        echo 'try { print(javax.swing.UIManager.getFont("Label.font").getFamily()); } catch (e) { print(e); java.lang.System.exit(1); }' | jjs


### PR DESCRIPTION
## Summary

- install `fontconfig` explicitly in the Corretto 8 native AL2 JDK and JRE images
- add an AL2-scoped Swing `UIManager` font-initialization regression test

## Background

On x86_64, the Corretto 8u492 AL2 runtime RPM contained JavaFX libraries including `libjavafx_font_pango.so` and `libglassgtk2.so`. Those libraries required `libfontconfig.so.1`, so the native Dockerfiles pulled in `fontconfig` transitively through `yum deplist`.

Those JavaFX libraries were removed from the x86_64 8u502 runtime RPM, which also removed the transitive `libfontconfig.so.1` requirement. The native AL2 Dockerfiles therefore stopped installing `fontconfig`. This causes Swing font initialization to fail with a `FontConfiguration` `NullPointerException` in the Docker Official Images `java-uimanager-font` test. The AL2 generic image is unaffected because it already installs `fontconfig` explicitly.

This change makes the existing font-support expectation explicit instead of relying on an optional component to provide it transitively.

Related failure: https://github.com/docker-library/official-images/pull/21894

## Architecture

The aarch64 runtime and devel RPMs contain no JavaFX in either 8u492 or 8u502, and neither version declares `libfontconfig.so.1`; there is no corresponding JavaFX-related dependency transition on aarch64. The Dockerfile fix is architecture-neutral: the arm64 base image resolves `fontconfig` for aarch64, while the existing `ARCH` detection downloads the aarch64 Corretto RPMs. This makes font support explicit on both supported architectures.

Runtime tests below were executed on x64 because the current CI and local builder are x64. The published aarch64 8u492 and 8u502 runtime/devel RPM metadata and payloads were checked separately.

## Scope

The Java 11 and 17 native AL2 Dockerfiles also resolve system packages through `yum deplist`, so they remain susceptible to future changes in transitive RPM requirements. They pass today; this PR is scoped to Java 8 because 8u502 is the release with the observed x86_64 regression.

## Testing

- built `8/jdk/al2/Dockerfile` and `8/jre/al2/Dockerfile` on x64
- passed the exact Docker Official Images `java-uimanager-font` test on both images
- passed the upstream container-structure-test suites on both images
- confirmed the AL2 regression test fails on the unpatched 8u502 JRE image with the original `NullPointerException`
- confirmed the aarch64 8u492 and 8u502 runtime/devel RPMs do not declare `libfontconfig.so.1`