### PR TITLE
Don't install weak dependencies for AL2023 headless 17+ images

### DIFF
--- a/17/headless/al2023/Dockerfile
+++ b/17/headless/al2023/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
-    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=False ${CORRETO_TEMP}/*.rpm \
     && popd \
     && rm -rf /usr/lib/jvm/java-17-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \

--- a/21/headless/al2023/Dockerfile
+++ b/21/headless/al2023/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
-    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=False ${CORRETO_TEMP}/*.rpm \
     && popd \
     && rm -rf /usr/lib/jvm/java-21-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \

--- a/25/headless/al2023/Dockerfile
+++ b/25/headless/al2023/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
-    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=False ${CORRETO_TEMP}/*.rpm \
     && popd \
     && rm -rf /usr/lib/jvm/java-25-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \

--- a/26/headless/al2023/Dockerfile
+++ b/26/headless/al2023/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
-    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=False ${CORRETO_TEMP}/*.rpm \
     && popd \
     && rm -rf /usr/lib/jvm/java-26-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \


### PR DESCRIPTION
*Issue #, if available:*

see: https://github.com/corretto/corretto-docker/issues/187

*Description of changes:*

Recommended dependencies will no long be installed in the AL2023 headless dockers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
