### PR TITLE
Redo "Don't install weak dependencies for AL2023 headless 17+ images …

### DIFF
--- a/17/headless/al2023/Dockerfile
+++ b/17/headless/al2023/Dockerfile
@@ -14,7 +14,8 @@ RUN set -eux \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
-    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs fontconfig \
     && popd \
     && rm -rf /usr/lib/jvm/java-17-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \

--- a/21/headless/al2023/Dockerfile
+++ b/21/headless/al2023/Dockerfile
@@ -14,7 +14,8 @@ RUN set -eux \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
-    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs fontconfig \
     && popd \
     && rm -rf /usr/lib/jvm/java-21-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \

--- a/25/headless/al2023/Dockerfile
+++ b/25/headless/al2023/Dockerfile
@@ -14,7 +14,8 @@ RUN set -eux \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
-    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs fontconfig \
     && popd \
     && rm -rf /usr/lib/jvm/java-25-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \

--- a/26/headless/al2023/Dockerfile
+++ b/26/headless/al2023/Dockerfile
@@ -14,7 +14,8 @@ RUN set -eux \
     curl --fail -O https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm} \
     && rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK" || exit 1; \
     done \
-    && dnf install -y ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs ${CORRETO_TEMP}/*.rpm \
+    && dnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs fontconfig \
     && popd \
     && rm -rf /usr/lib/jvm/java-26-amazon-corretto.${ARCH}/lib/src.zip \
     && rm -rf ${CORRETO_TEMP} \


### PR DESCRIPTION

*Issue #, if available:*

redoes https://github.com/corretto/corretto-docker/pull/287

*Description of changes:*
based off of:
- https://github.com/corretto/corretto-25/commit/74103cfcefeb98d64409ee216230bff43f40861b
- https://github.com/corretto/corretto-21/commit/a06381c70aa8c09d04c6af86c9873d94881bcdb9
- https://github.com/corretto/corretto-17/commit/ab8f8b4bb29795fc5e33eed3e5bff016f32cc136


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
